### PR TITLE
adds errorutils

### DIFF
--- a/errors/enriched.go
+++ b/errors/enriched.go
@@ -7,17 +7,19 @@ import (
 	"strings"
 )
 
+// ShowStackTrace in Error Message
+var ShowStackTrace bool = false
+
 // ErrCallback function to handle given error
 type ErrCallback func(level ErrorLevel, err string, tags ...string)
 
 // enrichedError is enriched version of normal error
 // with tags, stacktrace and other methods
 type enrichedError struct {
-	printStacktrace bool // default false
-	errString       string
-	StackTrace      string
-	Tags            []string
-	Level           ErrorLevel
+	errString  string
+	StackTrace string
+	Tags       []string
+	Level      ErrorLevel
 
 	//OnError is called when Error() method is triggered
 	OnError ErrCallback
@@ -50,7 +52,7 @@ func (e *enrichedError) Error() string {
 	label := fmt.Sprintf("[%v:%v]", strings.Join(e.Tags, ","), e.Level.String())
 	buff.WriteString(fmt.Sprintf("%v %v\n", label, e.errString))
 
-	if e.printStacktrace {
+	if ShowStackTrace {
 		e.captureStack()
 		buff.WriteString(fmt.Sprintf("Stacktrace:\n%v\n", e.StackTrace))
 	}
@@ -106,11 +108,6 @@ func (e *enrichedError) Equal(err ...error) bool {
 func (e *enrichedError) WithCallback(handle ErrCallback) Error {
 	e.OnError = handle
 	return e
-}
-
-// ShowStackTrace
-func (e *enrichedError) ShowStackTrace() {
-	e.printStacktrace = true
 }
 
 // captureStack

--- a/errors/enriched.go
+++ b/errors/enriched.go
@@ -1,0 +1,141 @@
+package errors
+
+import (
+	"bytes"
+	"fmt"
+	"runtime/debug"
+	"strings"
+)
+
+type ErrorLevel uint
+
+const (
+	Panic ErrorLevel = iota
+	Fatal
+	Runtime // Default
+)
+
+func (l ErrorLevel) String() string {
+	switch l {
+	case Panic:
+		return "PANIC"
+	case Fatal:
+		return "FTL"
+	case Runtime:
+		return "RUNTIME"
+	}
+	return ""
+}
+
+// *Error is enriched version of normal error
+// with tags, stacktrace and other methods
+type Error struct {
+	errString  string
+	StackTrace string
+	Tags       []string
+	Level      ErrorLevel
+
+	//OnError is called when Error() method is triggered
+	OnError func()
+}
+
+// withTag assignes tag to Error
+func (e *Error) WithTag(tag ...string) *Error {
+	if e.Tags == nil {
+		e.Tags = tag
+	} else {
+		e.Tags = append(e.Tags, tag...)
+	}
+	return e
+}
+
+// withLevel assinges level to Error
+func (e *Error) WithLevel(level ErrorLevel) *Error {
+	e.Level = level
+	return e
+}
+
+// returns formated *Error string
+func (e *Error) Error() string {
+	defer func() {
+		if e.OnError != nil {
+			e.OnError()
+		}
+	}()
+	e.captureStack()
+	var buff bytes.Buffer
+
+	if len(e.Tags) > 0 {
+		buff.WriteString(fmt.Sprintf("[%v]", strings.Join(e.Tags, " ")))
+	}
+	buff.WriteString(fmt.Sprintf("[%v] %v\n", e.Level.String(), e.errString))
+	buff.WriteString(fmt.Sprintf("Stacktrace:\n%v\n", e.StackTrace))
+	return buff.String()
+}
+
+// wraps given error
+func (e *Error) Wrap(err ...error) *Error {
+	// wraps like a stack
+	for _, v := range err {
+		if v == nil {
+			continue
+		}
+		e = e.Wrapf(v.Error())
+	}
+	return e
+}
+
+// Wrapf wraps given message
+func (e *Error) Wrapf(format string, args ...any) *Error {
+	// unlike wrapping `right -> left` it wraps like a stack (bottom -> up)
+	msg := fmt.Sprintf(format, args...)
+	if e.errString == "" {
+		e.errString = msg
+	} else {
+		e.errString = fmt.Sprintf("%v:\n%v", msg, e.errString)
+	}
+	return e
+}
+
+// captureStack
+func (e *Error) captureStack() {
+	// can be furthur improved to format
+	// ref https://github.com/go-errors/errors/blob/33d496f939bc762321a636d4035e15c302eb0b00/stackframe.go
+	e.StackTrace = string(debug.Stack())
+}
+
+// Equal returns true if error matches anyone of given errors
+func (e *Error) Equal(err ...error) bool {
+	for _, v := range err {
+		if ee, ok := v.(*Error); ok {
+			if e.errString == ee.errString {
+				return true
+			}
+		} else {
+			// not an enriched error but a simple eror
+			if e.errString == v.Error() {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// New
+func New(format string, args ...any) *Error {
+	ee := &Error{
+		errString: fmt.Sprintf(format, args...),
+	}
+	return ee
+}
+
+func NewWithErr(err error) *Error {
+	return New(err.Error())
+}
+
+// NewWithTag creates an error with tag
+func NewWithTag(tag string, format string, args ...any) *Error {
+	ee := New(format, args...)
+	ee.Tags = []string{tag}
+	return ee
+}

--- a/errors/enriched.go
+++ b/errors/enriched.go
@@ -64,10 +64,10 @@ func (e *enrichedError) Wrap(err ...error) Error {
 			continue
 		}
 		if ee, ok := v.(*enrichedError); ok {
-			e.Msgf(ee.errString).WithLevel(ee.Level).WithTag(ee.Tags...)
+			_ = e.Msgf(ee.errString).WithLevel(ee.Level).WithTag(ee.Tags...)
 			e.StackTrace += ee.StackTrace
 		} else {
-			e.Msgf(v.Error())
+			_ = e.Msgf(v.Error())
 		}
 	}
 	return e
@@ -103,8 +103,9 @@ func (e *enrichedError) Equal(err ...error) bool {
 }
 
 // WithCallback executes callback when error is triggered
-func (e *enrichedError) WithCallback(handle ErrCallback) {
+func (e *enrichedError) WithCallback(handle ErrCallback) Error {
 	e.OnError = handle
+	return e
 }
 
 // ShowStackTrace
@@ -142,6 +143,6 @@ func NewWithErr(err error) Error {
 // NewWithTag creates an error with tag
 func NewWithTag(tag string, format string, args ...any) Error {
 	ee := New(format, args...)
-	ee.WithTag(tag)
+	_ = ee.WithTag(tag)
 	return ee
 }

--- a/errors/enriched.go
+++ b/errors/enriched.go
@@ -7,40 +7,24 @@ import (
 	"strings"
 )
 
-type ErrorLevel uint
+// ErrCallback function to handle given error
+type ErrCallback func(level ErrorLevel, err string, tags ...string)
 
-const (
-	Panic ErrorLevel = iota
-	Fatal
-	Runtime // Default
-)
-
-func (l ErrorLevel) String() string {
-	switch l {
-	case Panic:
-		return "PANIC"
-	case Fatal:
-		return "FTL"
-	case Runtime:
-		return "RUNTIME"
-	}
-	return ""
-}
-
-// *Error is enriched version of normal error
+// enrichedError is enriched version of normal error
 // with tags, stacktrace and other methods
-type Error struct {
-	errString  string
-	StackTrace string
-	Tags       []string
-	Level      ErrorLevel
+type enrichedError struct {
+	printStacktrace bool // default false
+	errString       string
+	StackTrace      string
+	Tags            []string
+	Level           ErrorLevel
 
 	//OnError is called when Error() method is triggered
-	OnError func()
+	OnError ErrCallback
 }
 
 // withTag assignes tag to Error
-func (e *Error) WithTag(tag ...string) *Error {
+func (e *enrichedError) WithTag(tag ...string) Error {
 	if e.Tags == nil {
 		e.Tags = tag
 	} else {
@@ -50,64 +34,61 @@ func (e *Error) WithTag(tag ...string) *Error {
 }
 
 // withLevel assinges level to Error
-func (e *Error) WithLevel(level ErrorLevel) *Error {
+func (e *enrichedError) WithLevel(level ErrorLevel) Error {
 	e.Level = level
 	return e
 }
 
-// returns formated *Error string
-func (e *Error) Error() string {
+// returns formated *enrichedError string
+func (e *enrichedError) Error() string {
 	defer func() {
 		if e.OnError != nil {
-			e.OnError()
+			e.OnError(e.Level, e.errString, e.Tags...)
 		}
 	}()
-	e.captureStack()
 	var buff bytes.Buffer
+	label := fmt.Sprintf("[%v:%v]", strings.Join(e.Tags, ","), e.Level.String())
+	buff.WriteString(fmt.Sprintf("%v %v\n", label, e.errString))
 
-	if len(e.Tags) > 0 {
-		buff.WriteString(fmt.Sprintf("[%v]", strings.Join(e.Tags, " ")))
+	if e.printStacktrace {
+		e.captureStack()
+		buff.WriteString(fmt.Sprintf("Stacktrace:\n%v\n", e.StackTrace))
 	}
-	buff.WriteString(fmt.Sprintf("[%v] %v\n", e.Level.String(), e.errString))
-	buff.WriteString(fmt.Sprintf("Stacktrace:\n%v\n", e.StackTrace))
 	return buff.String()
 }
 
 // wraps given error
-func (e *Error) Wrap(err ...error) *Error {
-	// wraps like a stack
+func (e *enrichedError) Wrap(err ...error) Error {
 	for _, v := range err {
 		if v == nil {
 			continue
 		}
-		e = e.Wrapf(v.Error())
+		if ee, ok := v.(*enrichedError); ok {
+			e.Msgf(ee.errString).WithLevel(ee.Level).WithTag(ee.Tags...)
+			e.StackTrace += ee.StackTrace
+		} else {
+			e.Msgf(v.Error())
+		}
 	}
 	return e
 }
 
 // Wrapf wraps given message
-func (e *Error) Wrapf(format string, args ...any) *Error {
-	// unlike wrapping `right -> left` it wraps like a stack (bottom -> up)
+func (e *enrichedError) Msgf(format string, args ...any) Error {
+	// wraps with '<-` as delimeter
 	msg := fmt.Sprintf(format, args...)
 	if e.errString == "" {
 		e.errString = msg
 	} else {
-		e.errString = fmt.Sprintf("%v:\n%v", msg, e.errString)
+		e.errString = fmt.Sprintf("%v <- %v", msg, e.errString)
 	}
 	return e
 }
 
-// captureStack
-func (e *Error) captureStack() {
-	// can be furthur improved to format
-	// ref https://github.com/go-errors/errors/blob/33d496f939bc762321a636d4035e15c302eb0b00/stackframe.go
-	e.StackTrace = string(debug.Stack())
-}
-
 // Equal returns true if error matches anyone of given errors
-func (e *Error) Equal(err ...error) bool {
+func (e *enrichedError) Equal(err ...error) bool {
 	for _, v := range err {
-		if ee, ok := v.(*Error); ok {
+		if ee, ok := v.(*enrichedError); ok {
 			if e.errString == ee.errString {
 				return true
 			}
@@ -121,21 +102,46 @@ func (e *Error) Equal(err ...error) bool {
 	return false
 }
 
+// WithCallback executes callback when error is triggered
+func (e *enrichedError) WithCallback(handle ErrCallback) {
+	e.OnError = handle
+}
+
+// ShowStackTrace
+func (e *enrichedError) ShowStackTrace() {
+	e.printStacktrace = true
+}
+
+// captureStack
+func (e *enrichedError) captureStack() {
+	// can be furthur improved to format
+	// ref https://github.com/go-errors/errors/blob/33d496f939bc762321a636d4035e15c302eb0b00/stackframe.go
+	e.StackTrace = string(debug.Stack())
+}
+
 // New
-func New(format string, args ...any) *Error {
-	ee := &Error{
+func New(format string, args ...any) Error {
+	ee := &enrichedError{
 		errString: fmt.Sprintf(format, args...),
+		Level:     Runtime,
 	}
 	return ee
 }
 
-func NewWithErr(err error) *Error {
+func NewWithErr(err error) Error {
+	if err == nil {
+		return nil
+	}
+	if ee, ok := err.(*enrichedError); ok {
+		x := New(ee.errString).WithTag(ee.Tags...).WithLevel(ee.Level)
+		x.(*enrichedError).StackTrace = ee.StackTrace
+	}
 	return New(err.Error())
 }
 
 // NewWithTag creates an error with tag
-func NewWithTag(tag string, format string, args ...any) *Error {
+func NewWithTag(tag string, format string, args ...any) Error {
 	ee := New(format, args...)
-	ee.Tags = []string{tag}
+	ee.WithTag(tag)
 	return ee
 }

--- a/errors/err_test.go
+++ b/errors/err_test.go
@@ -1,0 +1,52 @@
+package errors_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/projectdiscovery/utils/errors"
+)
+
+func TestErrorEqual(t *testing.T) {
+	err1 := fmt.Errorf("error init x")
+	err2 := errors.NewWithErr(err1)
+	err3 := errors.NewWithTag("testing", "error init")
+	var errnil error
+
+	if !errors.IsAny(err1, err2, errnil) {
+		t.Errorf("expected errors to be equal")
+	}
+	if errors.IsAny(err1, err3, errnil) {
+		t.Errorf("expected error to be not equal")
+	}
+}
+
+func TestWrapWithNil(t *testing.T) {
+	err1 := errors.NewWithTag("niltest", "non nil error").WithLevel(errors.Fatal)
+	var errx error
+
+	if errors.WrapwithNil(errx, err1) != nil {
+		t.Errorf("when base error is nil ")
+	}
+}
+
+func TestStackTrace(t *testing.T) {
+	err := errors.New("base error")
+	relay := func(err error) error {
+		return err
+	}
+	errx := relay(err)
+
+	t.Run("teststack", func(t *testing.T) {
+		if strings.Contains(errx.Error(), "captureStack") {
+			t.Errorf("stacktrace should be disabled by default")
+		}
+		if ee, ok := errx.(errors.Error); ok {
+			ee.ShowStackTrace()
+		}
+		if !strings.Contains(errx.Error(), "captureStack") {
+			t.Errorf("missing stacktrace got %v", errx.Error())
+		}
+	})
+}

--- a/errors/err_test.go
+++ b/errors/err_test.go
@@ -50,3 +50,27 @@ func TestStackTrace(t *testing.T) {
 		}
 	})
 }
+
+func TestErrorCallback(t *testing.T) {
+	callbackExecuted := false
+
+	err := errors.NewWithTag("callback", "got error").WithCallback(func(level errors.ErrorLevel, err string, tags ...string) {
+		if level != errors.Runtime {
+			t.Errorf("Default error level should be Runtime")
+		}
+		if tags[0] != "callback" {
+			t.Errorf("missing callback")
+		}
+		callbackExecuted = true
+	})
+
+	errval := err.Error()
+
+	if !strings.Contains(errval, "callback") || !strings.Contains(errval, "got error") || !strings.Contains(errval, "RUNTIME") {
+		t.Errorf("error content missing expected values `callback,got error and Runtime` in error value but got %v", errval)
+	}
+
+	if !callbackExecuted {
+		t.Errorf("error callback failed to execute")
+	}
+}

--- a/errors/err_test.go
+++ b/errors/err_test.go
@@ -42,9 +42,7 @@ func TestStackTrace(t *testing.T) {
 		if strings.Contains(errx.Error(), "captureStack") {
 			t.Errorf("stacktrace should be disabled by default")
 		}
-		if ee, ok := errx.(errors.Error); ok {
-			ee.ShowStackTrace()
-		}
+		errors.ShowStackTrace = true
 		if !strings.Contains(errx.Error(), "captureStack") {
 			t.Errorf("missing stacktrace got %v", errx.Error())
 		}

--- a/errors/errinterface.go
+++ b/errors/errinterface.go
@@ -1,0 +1,20 @@
+package errors
+
+// Error is enriched version of normal error
+// with tags, stacktrace and other methods
+type Error interface {
+	// WithTag assigns tag[s] to Error
+	WithTag(tag ...string) Error
+	// WithLevel assigns given ErrorLevel
+	WithLevel(level ErrorLevel) Error
+	// Error is interface method of 'error'
+	Error() string
+	// Wraps existing error with errors (skips if passed error is nil)
+	Wrap(err ...error) Error
+	// Msgf wraps error with given message
+	Msgf(format string, args ...any) Error
+	// Equal Checks Equality of errors
+	Equal(err ...error) bool
+	// ShowStackTrace includes StackTrace with Error Message
+	ShowStackTrace()
+}

--- a/errors/errinterface.go
+++ b/errors/errinterface.go
@@ -15,8 +15,6 @@ type Error interface {
 	Msgf(format string, args ...any) Error
 	// Equal Checks Equality of errors
 	Equal(err ...error) bool
-	// ShowStackTrace includes StackTrace with Error Message
-	ShowStackTrace()
 	// WithCallback execute ErrCallback function when Error is triggered
 	WithCallback(handle ErrCallback) Error
 }

--- a/errors/errinterface.go
+++ b/errors/errinterface.go
@@ -17,4 +17,6 @@ type Error interface {
 	Equal(err ...error) bool
 	// ShowStackTrace includes StackTrace with Error Message
 	ShowStackTrace()
+	// WithCallback execute ErrCallback function when Error is triggered
+	WithCallback(handle ErrCallback) Error
 }

--- a/errors/errlevel.go
+++ b/errors/errlevel.go
@@ -1,0 +1,21 @@
+package errors
+
+type ErrorLevel uint
+
+const (
+	Panic ErrorLevel = iota
+	Fatal
+	Runtime // Default
+)
+
+func (l ErrorLevel) String() string {
+	switch l {
+	case Panic:
+		return "PANIC"
+	case Fatal:
+		return "FATAL"
+	case Runtime:
+		return "RUNTIME"
+	}
+	return "RUNTIME" //default is runtime
+}

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -7,9 +7,24 @@ func IsAny(err error, errxx ...error) bool {
 	if err == nil {
 		return false
 	}
-	for _, v := range errxx {
-		if err.Error() == v.Error() {
-			return true
+	if enrichedErr, ok := err.(Error); ok {
+		for _, v := range errxx {
+			if enrichedErr.Equal(v) {
+				return true
+			}
+		}
+	} else {
+		for _, v := range errxx {
+			if v == nil {
+				continue
+			}
+			if ee, ok := v.(Error); ok {
+				if ee.Equal(err) {
+					return true
+				}
+			} else if v.Error() == ee.Error() {
+				return true
+			}
 		}
 	}
 	return false
@@ -17,17 +32,17 @@ func IsAny(err error, errxx ...error) bool {
 
 // WrapfWithNil returns nil if error is nil but if err is not nil
 // wraps error with given msg unlike errors.Wrapf
-func WrapfWithNil(err error, format string, args ...any) *Error {
+func WrapfWithNil(err error, format string, args ...any) Error {
 	if err == nil {
 		return nil
 	}
 	ee := NewWithErr(err)
-	return ee.Wrapf(format, args...)
+	return ee.Msgf(format, args...)
 }
 
 // WrapwithNil returns nil if err is nil but wraps it with given
 // errors continuously if it is not nil
-func WrapwithNil(err error, errx ...error) *Error {
+func WrapwithNil(err error, errx ...error) Error {
 	if err == nil {
 		return nil
 	}

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -1,0 +1,36 @@
+package errors
+
+// IsAny checks if err is not nil and matches any one of errxx errors
+// if match successful returns true else false
+// Note: no unwrapping is done here
+func IsAny(err error, errxx ...error) bool {
+	if err == nil {
+		return false
+	}
+	for _, v := range errxx {
+		if err.Error() == v.Error() {
+			return true
+		}
+	}
+	return false
+}
+
+// WrapfWithNil returns nil if error is nil but if err is not nil
+// wraps error with given msg unlike errors.Wrapf
+func WrapfWithNil(err error, format string, args ...any) *Error {
+	if err == nil {
+		return nil
+	}
+	ee := NewWithErr(err)
+	return ee.Wrapf(format, args...)
+}
+
+// WrapwithNil returns nil if err is nil but wraps it with given
+// errors continuously if it is not nil
+func WrapwithNil(err error, errx ...error) *Error {
+	if err == nil {
+		return nil
+	}
+	ee := NewWithErr(err)
+	return ee.Wrap(errx...)
+}


### PR DESCRIPTION
# Proposed Changes

- Adds errorutils #36 
- Adds a `enrichedError` with methods similar to `gologger` for errors .
- Can print/show StackTrace in Error itself without panic.
- Includes callback function , errorlevel , tags etc 

- Public Error Interface

```go
// Error is enriched version of normal error
// with tags, stacktrace and other methods
type Error interface {
	// WithTag assigns tag[s] to Error
	WithTag(tag ...string) Error
	// WithLevel assigns given ErrorLevel
	WithLevel(level ErrorLevel) Error
	// Error is interface method of 'error'
	Error() string
	// Wraps existing error with errors (skips if passed error is nil)
	Wrap(err ...error) Error
	// Msgf wraps error with given message
	Msgf(format string, args ...any) Error
	// Equal Checks Equality of errors
	Equal(err ...error) bool
	// WithCallback execute ErrCallback function when Error is triggered
	WithCallback(handle ErrCallback) Error
}

```

closes #36 