### PR TITLE
adds url encoders

### DIFF
--- a/errors/enriched.go
+++ b/errors/enriched.go
@@ -1,4 +1,4 @@
-package errors
+package errorutil
 
 import (
 	"bytes"

--- a/errors/err_test.go
+++ b/errors/err_test.go
@@ -1,11 +1,11 @@
-package errors_test
+package errorutil_test
 
 import (
 	"fmt"
 	"strings"
 	"testing"
 
-	"github.com/projectdiscovery/utils/errors"
+	errors "github.com/projectdiscovery/utils/errors"
 )
 
 func TestErrorEqual(t *testing.T) {

--- a/errors/errinterface.go
+++ b/errors/errinterface.go
@@ -1,4 +1,4 @@
-package errors
+package errorutil
 
 // Error is enriched version of normal error
 // with tags, stacktrace and other methods

--- a/errors/errlevel.go
+++ b/errors/errlevel.go
@@ -1,4 +1,4 @@
-package errors
+package errorutil
 
 type ErrorLevel uint
 

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -1,4 +1,4 @@
-package errors
+package errorutil
 
 // IsAny checks if err is not nil and matches any one of errxx errors
 // if match successful returns true else false

--- a/url/rawparam.go
+++ b/url/rawparam.go
@@ -1,0 +1,187 @@
+package urlutil
+
+import (
+	"bytes"
+	"encoding/hex"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+/* Reserved Chars from RFC includes
+! * ' ( ) ; : @ & = + $ , / ? % # [ ]
+*/
+
+// MustEscapeCharSet are special chars that are always escaped and are based on reserved chars from RFC
+// Some of Reserved Chars From RFC were excluded and some were added for various reasons
+// and goal here is to encode parameters key and value only
+var MustEscapeCharSet []rune = []rune{'?', '#', '@', ';', '&', ',', '[', ']', '^'}
+
+type Params map[string][]string
+
+func NewParams() *Params {
+	p := make(Params)
+	return &p
+}
+
+// Add Parameters to store
+func (p Params) Add(key string, value string) {
+	if p.Has(key) {
+		p[key] = append(p[key], value)
+	} else {
+		p[key] = []string{value}
+	}
+}
+
+// Set sets the key to value and replaces if already exists
+func (p Params) Set(key string, value string) {
+	if p == nil {
+		p = make(Params)
+	}
+	p[key] = []string{value}
+}
+
+// Get returns first value of given key
+func (p Params) Get(key string) string {
+	if p.Has(key) {
+		return p[key][0]
+	} else {
+		return ""
+	}
+}
+
+// Has returns if given key exists
+func (p Params) Has(key string) bool {
+	if p == nil {
+		p = make(Params)
+	}
+	_, ok := p[key]
+	return ok
+}
+
+// Del deletes values associated with key
+func (p Params) Del(key string) {
+	if p == nil {
+		return
+	} else {
+		delete(p, key)
+	}
+}
+
+// Encode URL encodes and returns values ("bar=baz&foo=quux") sorted by key.
+func (p Params) Encode() string {
+	if p == nil {
+		return ""
+	}
+	var buf strings.Builder
+	keys := make([]string, 0, len(p))
+	for k := range p {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		vs := p[k]
+		keyEscaped := ParamEncode(k)
+		for _, v := range vs {
+			if buf.Len() > 0 {
+				buf.WriteByte('&')
+			}
+			buf.WriteString(keyEscaped)
+			buf.WriteByte('=')
+			buf.WriteString(ParamEncode(v))
+		}
+	}
+	return buf.String()
+}
+
+// ParamEncode  encodes Key characters only. key characters include
+// whitespaces + non printable chars + non-ascii + `almost` all reserved
+// with some execptions i.e (). and other
+// also this does not double encode encoded characters
+func ParamEncode(data string) string {
+	return URLEncodeWithEscapes(data, MustEscapeCharSet...)
+}
+
+// URLEncodeWithEscapes URL encodes data with given special characters escaped (similar to burpsuite intruder)
+// Note `MustEscapeCharSet` is not included
+func URLEncodeWithEscapes(data string, charset ...rune) string {
+	mustescape := getrunemap(charset)
+	var buff bytes.Buffer
+	totallen := len(data)
+	// In any case
+	buff.Grow(totallen)
+
+	for _, r := range data {
+		switch true {
+		case r < rune(20):
+			// control character
+			buff.WriteRune('%')
+			buff.WriteString(strconv.FormatInt(int64(r), 16)) // 2 digit hex
+		case r == ' ':
+			// prefer using + when space
+			buff.WriteRune('+')
+			// case
+		case r < rune(127):
+			if _, ok := mustescape[r]; ok {
+				// reserved char must escape
+				buff.WriteRune('%')
+				buff.WriteString(strconv.FormatInt(int64(r), 16))
+			} else {
+				// do not percent encode
+				buff.WriteRune(r)
+			}
+		case r == rune(127):
+			// [DEL] char should be encoded
+			buff.WriteRune('%')
+			buff.WriteString(strconv.FormatInt(int64(r), 16))
+		case r > rune(128):
+			// non-ascii characters i.e chinese chars or any other utf-8
+			buff.WriteRune('%')
+			buff.WriteString(getutf8hex(r))
+		}
+	}
+	return buff.String()
+}
+
+// PercentEncoding encodes all characters to percent encoded format just like burpsuite decoder
+func PercentEncoding(data string) string {
+	var buff bytes.Buffer
+	totallen := len(data)
+	// In any case
+	buff.Grow(totallen)
+	for _, r := range data {
+		buff.WriteRune('%')
+		if r <= rune(127) {
+			// these are all ascii characters
+			buff.WriteString(strconv.FormatInt(int64(r), 16))
+		} else {
+			// unicode characters
+			buff.WriteString(getutf8hex(r))
+		}
+	}
+	return buff.String()
+}
+
+func getrunemap(runes []rune) map[rune]struct{} {
+	x := map[rune]struct{}{}
+	for _, v := range runes {
+		x[v] = struct{}{}
+	}
+	return x
+}
+
+func getutf8hex(r rune) string {
+	// Percent Encoding is only done in hexadecimal values and in ASCII Range only
+	// other UTF-8 chars (chinese etc) can be used by utf-8 encoding and byte conversion
+	// let golang do utf-8 encoding of rune
+	var buff bytes.Buffer
+	utfchar := string(r)
+	hexencstr := hex.EncodeToString([]byte(utfchar))
+	for k, v := range hexencstr {
+		if k != 0 && k%2 == 0 {
+			buff.WriteRune('%')
+		}
+		buff.WriteRune(v)
+	}
+	return buff.String()
+}

--- a/url/rawparam.go
+++ b/url/rawparam.go
@@ -3,6 +3,7 @@ package urlutil
 import (
 	"bytes"
 	"encoding/hex"
+	"net/url"
 	"sort"
 	"strconv"
 	"strings"
@@ -19,9 +20,9 @@ var MustEscapeCharSet []rune = []rune{'?', '#', '@', ';', '&', ',', '[', ']', '^
 
 type Params map[string][]string
 
-func NewParams() *Params {
+func NewParams() Params {
 	p := make(Params)
-	return &p
+	return p
 }
 
 // Add Parameters to store
@@ -160,6 +161,18 @@ func PercentEncoding(data string) string {
 		}
 	}
 	return buff.String()
+}
+
+// GetParams return Params type using url.Values
+func GetParams(query url.Values) Params {
+	if query == nil {
+		return nil
+	}
+	p := NewParams()
+	for k, v := range query {
+		p[k] = v
+	}
+	return p
 }
 
 func getrunemap(runes []rune) map[rune]struct{} {

--- a/url/rawparam_test.go
+++ b/url/rawparam_test.go
@@ -55,6 +55,7 @@ func TestParamIntegration(t *testing.T) {
 		}
 		w.WriteHeader(http.StatusOK)
 	})
+	//nolint:all
 	go http.ListenAndServe(":9000", nil)
 
 	p := NewParams()

--- a/url/rawparam_test.go
+++ b/url/rawparam_test.go
@@ -1,0 +1,85 @@
+package urlutil
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"testing"
+)
+
+func TestUTF8URLEncoding(t *testing.T) {
+	exstring := '上'
+	expected := `e4%b8%8a`
+	val := getutf8hex(exstring)
+	if val != expected {
+		t.Errorf("failed to url encode utf char expected %v but got %v", expected, val)
+	}
+}
+
+func TestParamEncoding(t *testing.T) {
+	testcases := []struct {
+		Payload  string
+		Expected string
+	}{
+		{"1+AND+(SELECT+*+FROM+(SELECT(SLEEP(12)))nQIP)", "1+AND+(SELECT+*+FROM+(SELECT(SLEEP(12)))nQIP)"},
+		{"1 AND SELECT", "1+AND+SELECT"},
+	}
+	for _, v := range testcases {
+		val := ParamEncode(v.Payload)
+		if val != v.Expected {
+			t.Errorf("failed to url encode payload expected %v got %v", v.Expected, val)
+		}
+	}
+}
+
+func TestRawParam(t *testing.T) {
+	p := NewParams()
+	p.Add("sqli", "1+AND+(SELECT+*+FROM+(SELECT(SLEEP(12)))nQIP)")
+	p.Add("xss", "<script>alert('XSS')</script>")
+	p.Add("xssiwthspace", "<svg id=alert(1) onload=eval(id)>")
+	p.Add("jsprotocol", "javascript://alert(1)")
+	// Note keys are sorted
+	expected := "jsprotocol=javascript://alert(1)&sqli=1+AND+(SELECT+*+FROM+(SELECT(SLEEP(12)))nQIP)&xss=<script>alert('XSS')</script>&xssiwthspace=<svg+id=alert(1)+onload=eval(id)>"
+	if p.Encode() != expected {
+		t.Errorf("failed to encode parameters expected %v but got %v", expected, p.Encode())
+	}
+}
+
+func TestParamIntegration(t *testing.T) {
+	var routerErr error
+	expected := "/params?jsprotocol=javascript://alert(1)&sqli=1+AND+(SELECT+*+FROM+(SELECT(SLEEP(12)))nQIP)&xss=<script>alert('XSS')</script>&xssiwthspace=<svg+id=alert(1)+onload=eval(id)>"
+
+	http.HandleFunc("/params", func(w http.ResponseWriter, r *http.Request) {
+		if r.RequestURI != expected {
+			routerErr = fmt.Errorf("expected %v but got %v", expected, r.RequestURI)
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+	go http.ListenAndServe(":9000", nil)
+
+	p := NewParams()
+	p.Add("sqli", "1+AND+(SELECT+*+FROM+(SELECT(SLEEP(12)))nQIP)")
+	p.Add("xss", "<script>alert('XSS')</script>")
+	p.Add("xssiwthspace", "<svg id=alert(1) onload=eval(id)>")
+	p.Add("jsprotocol", "javascript://alert(1)")
+
+	url, _ := url.Parse("http://localhost:9000/params")
+	url.RawQuery = p.Encode()
+	_, err := http.Get(url.String())
+	if err != nil {
+		panic(err)
+	}
+	if routerErr != nil {
+		t.Errorf(routerErr.Error())
+	}
+}
+
+func TestPercentEncoding(t *testing.T) {
+	// From Burpsuite
+	expected := "%74%65%73%74%20%26%23%20%28%29%20%70%65%72%63%65%6e%74%20%5b%5d%7c%2a%20%65%6e%63%6f%64%69%6e%67"
+	payload := "test &# () percent []|* encoding"
+	value := PercentEncoding(payload)
+	if value != expected {
+		t.Errorf("expected percentencoding to be %v but got %v", expected, payload)
+	}
+}

--- a/url/rawparam_test.go
+++ b/url/rawparam_test.go
@@ -84,3 +84,19 @@ func TestPercentEncoding(t *testing.T) {
 		t.Errorf("expected percentencoding to be %v but got %v", expected, payload)
 	}
 }
+
+func TestGetParams(t *testing.T) {
+	values := url.Values{}
+	values.Add("sqli", "1+AND+(SELECT+*+FROM+(SELECT(SLEEP(12)))nQIP)")
+	values.Add("xss", "<script>alert('XSS')</script>")
+	p := GetParams(values)
+	if p == nil {
+		t.Errorf("expected params but got nil")
+	}
+	if p.Get("sqli") != values.Get("sqli") {
+		t.Errorf("malformed or missing value for param sqli expected %v but got %v", values.Get("sqli"), p.Get("sqli"))
+	}
+	if p.Get("xss") != values.Get("xss") {
+		t.Errorf("malformed or missing value for param xss expected %v but got %v", values.Get("xss"), p.Get("xss"))
+	}
+}


### PR DESCRIPTION
# Proposed Changes

- Adds URL Encoding of Parameters  https://github.com/projectdiscovery/nuclei/issues/2698
- API Changes
   - Adds type `Params` Similar to `url.Values`
   - `ParamEncode(data string) string` - url encoder that only encodes key characters
   - `PercentEncoding(data string) string` - encodes all given data (similar to burpsuite decoder tab)
   - `URLEncodeWithEscapes(data string, charset ...rune) string ` - URL Encodes with given escapes. i.e  apart from encoding non printable chars and utf chars , it encodes any given special chars (ex: ()/ etc) . similar to burpsuite
![Screenshot 2023-01-04 at 7 43 22 PM](https://user-images.githubusercontent.com/45962551/210573930-89c6da1d-63f6-464f-95ca-5448064c0865.png)

- Helper `GetParams(query url.values)` returns params from `url.values`
- Decoder is not introduced in this PR and `url.QueryUnescape()` should be used
  

closes #39 