### PR TITLE
Adding proxy utils

### DIFF
--- a/http/proxy/proxy.go
+++ b/http/proxy/proxy.go
@@ -1,0 +1,75 @@
+package proxy
+
+import (
+	"bytes"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+)
+
+// IsBurp checks if the target proxy URL is burp suite
+func IsBurp(proxyURL string) (bool, error) {
+	return getURLWithHTTPProxy("http://burpsuite/", proxyURL, func(resp *http.Response) (bool, error) {
+		if resp.StatusCode != http.StatusOK {
+			return false, fmt.Errorf("unexpected status code (200 wanted): %d", resp.StatusCode)
+		}
+
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return false, err
+		}
+
+		defer resp.Body.Close()
+
+		return bytes.Contains(body, []byte("Burp Suite")), nil
+	})
+}
+
+// ValidateOne returns the first valid proxy from a list of proxies
+func ValidateOne(proxies ...string) (string, error) {
+	for _, proxy := range proxies {
+		ok, err := getURLWithHTTPProxy("https://scanme.sh", proxy, func(resp *http.Response) (bool, error) {
+			if resp.StatusCode != http.StatusOK {
+				return false, fmt.Errorf("unexpected status code (200 wanted): %d", resp.StatusCode)
+			}
+
+			body, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return false, err
+			}
+			defer resp.Body.Close()
+
+			return len(body) > 0, nil
+		})
+		if ok {
+			return proxy, err
+		}
+	}
+
+	return "", errors.New("no valid proxy found")
+}
+
+func getURLWithHTTPProxy(targetURL, proxyURL string, checkCallback func(resp *http.Response) (bool, error)) (bool, error) {
+	URL, err := url.Parse(proxyURL)
+	if err != nil {
+		return false, err
+	}
+	httpClient := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true,
+			},
+			Proxy: http.ProxyURL(URL),
+		},
+	}
+
+	resp, err := httpClient.Get(targetURL)
+	if err != nil {
+		return false, err
+	}
+
+	return checkCallback(resp)
+}

--- a/http/proxy/proxy_test.go
+++ b/http/proxy/proxy_test.go
@@ -1,0 +1,28 @@
+//go:build proxy
+
+package proxy
+
+// package tests will be executed only with (running proxy is necessary):
+// go test -tags proxy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const burpURL = "http://127.0.0.1:8080"
+
+// a local instance of burp community is necessary
+func TestIsBurp(t *testing.T) {
+	ok, err := IsBurp(burpURL)
+	require.Nil(t, err)
+	require.True(t, ok)
+}
+
+// a valid proxy is necessary
+func TestValidateOne(t *testing.T) {
+	proxyURL, err := ValidateOne(burpURL)
+	require.Nil(t, err)
+	require.Equal(t, burpURL, proxyURL)
+}


### PR DESCRIPTION
With a running instance of burp proxy listening on `http://127.0.0.1:8080`:
```console
$ go test -tags proxy .\...
ok      github.com/projectdiscovery/utils/http/proxy    1.388s
```

Closes #54 

