### PR TITLE
Adding new err with fmt type

### DIFF
--- a/errors/err_with_fmt.go
+++ b/errors/err_with_fmt.go
@@ -1,0 +1,27 @@
+package errorutil
+
+import (
+	"fmt"
+)
+
+// ErrWithFmt is a simplified version of err holding a default format
+type ErrWithFmt struct {
+	fmt string
+}
+
+// Wrapf wraps given message
+func (e *ErrWithFmt) Msgf(args ...any) error {
+	return fmt.Errorf(e.fmt, args...)
+}
+
+func (e *ErrWithFmt) Error() {
+	panic("ErrWithFmt is a format holder")
+}
+
+func NewWithFmt(fmt string) ErrWithFmt {
+	if fmt == "" {
+		panic("format can't be empty")
+	}
+
+	return ErrWithFmt{fmt: fmt}
+}

--- a/errors/err_with_fmt_test.go
+++ b/errors/err_with_fmt_test.go
@@ -1,0 +1,17 @@
+package errorutil_test
+
+import (
+	"testing"
+
+	errors "github.com/projectdiscovery/utils/errors"
+	"github.com/stretchr/testify/require"
+)
+
+func TestErrWithFmt(t *testing.T) {
+	errBase := errors.NewWithFmt("error: %s")
+	errWithMsg1 := errBase.Msgf("test1")
+	errWithMsg2 := errBase.Msgf("test2")
+
+	require.Equal(t, "error: test1", errWithMsg1.Error())
+	require.Equal(t, "error: test2", errWithMsg2.Error())
+}


### PR DESCRIPTION
## Description
This PR adds a new base error generator which holds a standard format and creates new error bindings values:
```
errBase := errors.NewWithFmt("error: %s")
errWithMsg1 := errBase.Msgf("test1")
```

This might be useful for cases with a standard format but different arguments.