### PR TITLE
adding permission to FreeBSD

### DIFF
--- a/permission/permission_freebsd.go
+++ b/permission/permission_freebsd.go
@@ -1,0 +1,17 @@
+//go:build freebsd
+
+package permissionutil
+
+import (
+	"os"
+)
+
+// checkCurrentUserRoot checks if the current user is root
+func checkCurrentUserRoot() (bool, error) {
+	return os.Geteuid() == 0, nil
+}
+
+// checkCurrentUserCapNetRaw checks if the current user has the CAP_NET_RAW capability
+func checkCurrentUserCapNetRaw() (bool, error) {
+	return false, ErrNotImplemented
+}

--- a/permission/permission_other.go
+++ b/permission/permission_other.go
@@ -1,4 +1,4 @@
-//go:build freebsd
+//go:build freebsd || netbsd || openbsd || solaris || android || ios
 
 package permissionutil
 


### PR DESCRIPTION
Hi guys!

I'm the maintainer of the Nuclei on FreeBSD ports:
https://www.freshports.org/security/nuclei

I'm porting the Katana to FreeBSD, but at the build stage I receive this error. this PR fixed that bug.

```
---
github.com/projectdiscovery/utils/permission
# github.com/projectdiscovery/utils/permission
vendor/github.com/projectdiscovery/utils/permission/permission.go:9:14: undefined: checkCurrentUserRoot
vendor/github.com/projectdiscovery/utils/permission/permission.go:10:20: undefined: checkCurrentUserCapNetRaw
```