### PR TITLE
 "IsIP" and "IsIPv4" are not able to i identify short ip address as Valid Ip address

### DIFF
--- a/consts/errors.go
+++ b/consts/errors.go
@@ -1,0 +1,7 @@
+package consts
+
+import "errors"
+
+var (
+	ErrNotSupported = errors.New("not supported")
+)

--- a/ip/iputil.go
+++ b/ip/iputil.go
@@ -72,35 +72,14 @@ func init() {
 
 // IsIP checks if a string is either IP version 4 or 6. Alias for `net.ParseIP`
 func IsIP(str string) bool {
-	parts := strings.Split(str, ".")
-	numParts := len(parts)
-
 	// try to parse ip first
 	ipParsed := net.ParseIP(str)
 	if ipParsed != nil {
 		return true
 	}
 
-	if numParts < 1 || numParts > 4 {
-		return false
-	}
-
-	// fill in missing parts with zeroes
-	for i := 0; i < 4-numParts; i++ {
-		parts = append(parts, "0")
-	}
-
-	if numParts == 2 {
-		parts[1], parts[3] = parts[3], parts[1]
-	}
-	if numParts == 3 {
-		parts[2], parts[3] = parts[3], parts[2]
-	}
-
-	// parse the complete IPv4 address
-	ip := net.ParseIP(strings.Join(parts, "."))
-
-	return ip != nil
+	// try to parse as IPv4 or IPv6
+	return IsIPv4(str) || IsIPv6(str)
 }
 
 // IsPort checks if a string represents a valid port
@@ -114,19 +93,39 @@ func IsPort(str string) bool {
 // IsIPv4 checks if the string is an IP version 4.
 func IsIPv4(ips ...interface{}) bool {
 	for _, ip := range ips {
+		var processedIp string
 		switch ipv := ip.(type) {
 		case string:
-			parsedIP := net.ParseIP(ipv)
-			isIP4 := parsedIP != nil && parsedIP.To4() != nil && stringsutil.ContainsAny(ipv, ".")
-			if !isIP4 {
-				return false
-			}
+			processedIp = ipv
 		case net.IP:
-			isIP4 := ipv != nil && ipv.To4() != nil && stringsutil.ContainsAny(ipv.String(), ".")
-			if !isIP4 {
-				return false
-			}
+			processedIp = ipv.String()
+		default:
+			return false
 		}
+
+		parts := strings.Split(processedIp, ".")
+		numParts := len(parts)
+
+		if numParts < 1 || numParts > 4 {
+			return false
+		}
+
+		// fill in missing parts with zeroes
+		for i := 0; i < 4-numParts; i++ {
+			parts = append(parts, "0")
+		}
+
+		if numParts == 2 {
+			parts[1], parts[3] = parts[3], parts[1]
+		}
+		if numParts == 3 {
+			parts[2], parts[3] = parts[3], parts[2]
+		}
+
+		// parse the complete IPv4 address
+		ip := net.ParseIP(strings.Join(parts, "."))
+
+		return ip != nil
 	}
 
 	return true

--- a/ip/iputil.go
+++ b/ip/iputil.go
@@ -72,7 +72,29 @@ func init() {
 
 // IsIP checks if a string is either IP version 4 or 6. Alias for `net.ParseIP`
 func IsIP(str string) bool {
-	return net.ParseIP(str) != nil
+	parts := strings.Split(str, ".")
+	numParts := len(parts)
+
+	if numParts < 1 || numParts > 4 {
+		return false
+	}
+
+	// fill in missing parts with zeroes
+	for i := 0; i < 4-numParts; i++ {
+		parts = append(parts, "0")
+	}
+
+	if numParts == 2 {
+		parts[1], parts[3] = parts[3], parts[1]
+	}
+	if numParts == 3 {
+		parts[2], parts[3] = parts[3], parts[2]
+	}
+
+	// parse the complete IPv4 address
+	ip := net.ParseIP(strings.Join(parts, "."))
+
+	return ip != nil
 }
 
 // IsPort checks if a string represents a valid port

--- a/ip/iputil.go
+++ b/ip/iputil.go
@@ -124,8 +124,9 @@ func IsIPv4(ips ...interface{}) bool {
 
 		// parse the complete IPv4 address
 		ip := net.ParseIP(strings.Join(parts, "."))
-
-		return ip != nil
+		if ip == nil {
+			return false
+		}
 	}
 
 	return true

--- a/ip/iputil.go
+++ b/ip/iputil.go
@@ -75,6 +75,12 @@ func IsIP(str string) bool {
 	parts := strings.Split(str, ".")
 	numParts := len(parts)
 
+	// try to parse ip first
+	ipParsed := net.ParseIP(str)
+	if ipParsed != nil {
+		return true
+	}
+
 	if numParts < 1 || numParts > 4 {
 		return false
 	}

--- a/ip/iputil.go
+++ b/ip/iputil.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"runtime"
 	"strconv"
 	"strings"
 
@@ -84,20 +85,20 @@ func IsPort(str string) bool {
 }
 
 func IsShortIPv4(ips ...string) bool {
+	if runtime.GOOS == "windows" {
+		panic("not supported")
+	}
+
 	for _, ip := range ips {
-		splitIP := strings.Split(ip, ".")
-		if len(splitIP) < 2 || len(splitIP) > 4 {
+		var isIP4 bool
+		tcpAddr, err := net.ResolveTCPAddr("tcp", ip+":80")
+		if err != nil {
 			return false
 		}
-		for _, octet := range splitIP {
-			num, err := strconv.Atoi(octet)
-			if err != nil || num < 0 || num > 255 {
-				return false
-			}
-		}
 
-		_, err := net.ResolveTCPAddr("tcp", ip+":80")
-		if err != nil {
+		parsedIP := tcpAddr.IP
+		isIP4 = parsedIP != nil && parsedIP.To4() != nil && strings.HasPrefix(parsedIP.String(), ip)
+		if !isIP4 {
 			return false
 		}
 	}

--- a/ip/iputil.go
+++ b/ip/iputil.go
@@ -97,7 +97,7 @@ func IsShortIPv4(ips ...string) bool {
 		}
 
 		parsedIP := tcpAddr.IP
-		isIP4 = parsedIP != nil && parsedIP.To4() != nil && strings.HasPrefix(parsedIP.String(), ip)
+		isIP4 = parsedIP != nil && parsedIP.To4() != nil && strings.Contains(ip, ".")
 		if !isIP4 {
 			return false
 		}

--- a/ip/iputil.go
+++ b/ip/iputil.go
@@ -83,32 +83,36 @@ func IsPort(str string) bool {
 	return false
 }
 
+func isValidShortIP(ip string) bool {
+	splitIP := strings.Split(ip, ".")
+	if len(splitIP) < 2 || len(splitIP) > 4 {
+		return false
+	}
+	for _, octet := range splitIP {
+		num, err := strconv.Atoi(octet)
+		if err != nil || num < 0 || num > 255 {
+			return false
+		}
+	}
+	return true
+}
+
 // IsIPv4 checks if the string is an IP version 4.
 func IsIPv4(ips ...interface{}) bool {
 	for _, ip := range ips {
 		var isIP4 bool
 		switch ipv := ip.(type) {
 		case string:
-			tcpAddr, err := net.ResolveTCPAddr("tcp", ipv+":80")
-			if err != nil {
-				return false
-			}
-
-			parsedIP := tcpAddr.IP
-			isIP4 = parsedIP != nil && parsedIP.To4() != nil && ipv == parsedIP.String()
-			if !isIP4 {
-				// Check if it's a valid short IP
-				splitIP := strings.Split(ipv, ".")
-				if len(splitIP) >= 2 && len(splitIP) <= 4 {
-					isIP4 = true
-					for _, octet := range splitIP {
-						num, err := strconv.Atoi(octet)
-						if err != nil || num < 0 || num > 255 {
-							isIP4 = false
-							break
-						}
-					}
+			if isValidShortIP(ipv) {
+				isIP4 = true
+			} else {
+				tcpAddr, err := net.ResolveTCPAddr("tcp", ipv+":80")
+				if err != nil {
+					return false
 				}
+
+				parsedIP := tcpAddr.IP
+				isIP4 = parsedIP != nil && parsedIP.To4() != nil && ipv == parsedIP.String()
 			}
 		case net.IP:
 			isIP4 = ipv != nil && ipv.To4() != nil && stringsutil.ContainsAny(ipv.String(), ".")

--- a/ip/iputil.go
+++ b/ip/iputil.go
@@ -83,43 +83,43 @@ func IsPort(str string) bool {
 	return false
 }
 
-func isValidShortIP(ip string) bool {
-	splitIP := strings.Split(ip, ".")
-	if len(splitIP) < 2 || len(splitIP) > 4 {
-		return false
-	}
-	for _, octet := range splitIP {
-		num, err := strconv.Atoi(octet)
-		if err != nil || num < 0 || num > 255 {
+func IsShortIPv4(ips ...string) bool {
+	for _, ip := range ips {
+		splitIP := strings.Split(ip, ".")
+		if len(splitIP) < 2 || len(splitIP) > 4 {
+			return false
+		}
+		for _, octet := range splitIP {
+			num, err := strconv.Atoi(octet)
+			if err != nil || num < 0 || num > 255 {
+				return false
+			}
+		}
+
+		_, err := net.ResolveTCPAddr("tcp", ip+":80")
+		if err != nil {
 			return false
 		}
 	}
+
 	return true
 }
 
 // IsIPv4 checks if the string is an IP version 4.
 func IsIPv4(ips ...interface{}) bool {
 	for _, ip := range ips {
-		var isIP4 bool
 		switch ipv := ip.(type) {
 		case string:
-			if isValidShortIP(ipv) {
-				isIP4 = true
-			} else {
-				tcpAddr, err := net.ResolveTCPAddr("tcp", ipv+":80")
-				if err != nil {
-					return false
-				}
-
-				parsedIP := tcpAddr.IP
-				isIP4 = parsedIP != nil && parsedIP.To4() != nil && ipv == parsedIP.String()
+			parsedIP := net.ParseIP(ipv)
+			isIP4 := parsedIP != nil && parsedIP.To4() != nil && strings.Contains(ipv, ".")
+			if !isIP4 {
+				return false
 			}
 		case net.IP:
-			isIP4 = ipv != nil && ipv.To4() != nil && stringsutil.ContainsAny(ipv.String(), ".")
-		}
-
-		if !isIP4 {
-			return false
+			isIP4 := ipv != nil && ipv.To4() != nil && strings.Contains(ipv.String(), ".")
+			if !isIP4 {
+				return false
+			}
 		}
 	}
 

--- a/ip/iputil_test.go
+++ b/ip/iputil_test.go
@@ -102,12 +102,17 @@ func TestIsPort(t *testing.T) {
 
 func TestIsIPv4(t *testing.T) {
 	require.True(t, IsIPv4("127.0.0.1"), "valid ipv4 address not recognized")
+	require.True(t, IsIPv4("127.1"), "valid ipv4 address not recognized")
+	require.True(t, IsIPv4("127.1.1"), "valid ipv4 address not recognized")
 	require.False(t, IsIPv4("2001:0db8:85a3:0000:0000:8a2e:0370:7334"), "ipv6 address recognized as valid")
 }
 
 func TestIsIPv6(t *testing.T) {
 	require.False(t, IsIPv6("127.0.0.1"), "ipv4 address recognized as valid")
 	require.True(t, IsIPv6("2001:0db8:85a3:0000:0000:8a2e:0370:7334"), "valid ipv6 address not recognized")
+	require.True(t, IsIPv6("::a00:27ff:fef3:7d56"), "valid ipv6 address not recognized")
+	require.True(t, IsIPv6("001:0db8::1"), "valid ipv6 address not recognized")
+	require.True(t, IsIPv6("::1"), "valid ipv6 address not recognized")
 }
 
 func TestIsCIDR(t *testing.T) {

--- a/ip/iputil_test.go
+++ b/ip/iputil_test.go
@@ -7,9 +7,78 @@ import (
 )
 
 func TestIsIP(t *testing.T) {
-	require.True(t, IsIP("127.0.0.1"), "valid ip not recognized")
-	require.False(t, IsIP("127.0.0.0/24"), "cidr recognized as ip")
-	require.False(t, IsIP("test"), "string recognized as ip")
+	type test struct {
+		Ip           string
+		Expected     bool
+		MessageError string
+	}
+
+	validIpsTest := []test{
+		{
+			Ip:           "35.1",
+			Expected:     true,
+			MessageError: "valid ip not recognized",
+		},
+		{
+			Ip:           "35.1.124",
+			Expected:     true,
+			MessageError: "valid ip not recognized",
+		},
+		{
+			Ip:           "35.1.1.124",
+			Expected:     true,
+			MessageError: "valid ip not recognized",
+		},
+		{
+			Ip:           "127.1",
+			Expected:     true,
+			MessageError: "valid ip not recognized",
+		},
+		{
+			Ip:           "127.1.1",
+			Expected:     true,
+			MessageError: "valid ip not recognized",
+		},
+		{
+			Ip:           "::1",
+			Expected:     true,
+			MessageError: "valid ip not recognized",
+		},
+		{
+			Ip:           "001:0db8::1",
+			Expected:     true,
+			MessageError: "valid ip not recognized",
+		},
+		{
+			Ip:           "::a00:27ff:fef3:7d56",
+			Expected:     true,
+			MessageError: "valid ip not recognized",
+		},
+		{
+			Ip:           "fe80::a00:27ff:fef3:7d56",
+			Expected:     true,
+			MessageError: "valid ip not recognized",
+		},
+		{
+			Ip:           "2607:f0d0:1002:0051:0000:0000:0000:0004",
+			Expected:     true,
+			MessageError: "valid ip not recognized",
+		},
+		{
+			Ip:           "127.0.0.1/24",
+			Expected:     false,
+			MessageError: "cidr reconized as ip",
+		},
+		{
+			Ip:           "test",
+			Expected:     false,
+			MessageError: "string reconized as ip",
+		},
+	}
+
+	for _, ip := range validIpsTest {
+		require.Equal(t, ip.Expected, IsIP(ip.Ip), ip.MessageError)
+	}
 }
 
 func TestIsInternalIPv4(t *testing.T) {

--- a/ip/iputil_test.go
+++ b/ip/iputil_test.go
@@ -15,16 +15,6 @@ func TestIsIPv4Short(t *testing.T) {
 
 	validIpsTest := []test{
 		{
-			Ip:           "35.1",
-			Expected:     true,
-			MessageError: "valid ip not recognized",
-		},
-		{
-			Ip:           "35.1.124",
-			Expected:     true,
-			MessageError: "valid ip not recognized",
-		},
-		{
 			Ip:           "192.168.1",
 			Expected:     true,
 			MessageError: "valid ip not recognized",

--- a/ip/iputil_test.go
+++ b/ip/iputil_test.go
@@ -1,6 +1,7 @@
 package iputil
 
 import (
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -29,6 +30,10 @@ func TestIsShortIPv4(t *testing.T) {
 			Expected:     true,
 			MessageError: "valid ip not recognized",
 		},
+	}
+
+	if runtime.GOOS == "windows" {
+		require.PanicsWithValue(t, "not supported", func() { IsShortIPv4("192.168.1") }, "Function should panic with 'not supported' on Windows")
 	}
 
 	for _, ip := range validIpsTest {

--- a/ip/iputil_test.go
+++ b/ip/iputil_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestIsIPv4Short(t *testing.T) {
+func TestIsShortIPv4(t *testing.T) {
 	type test struct {
 		Ip           string
 		Expected     bool
@@ -32,7 +32,7 @@ func TestIsIPv4Short(t *testing.T) {
 	}
 
 	for _, ip := range validIpsTest {
-		require.Equal(t, ip.Expected, IsIPv4(ip.Ip), ip.MessageError, ip.Ip)
+		require.Equal(t, ip.Expected, IsShortIPv4(ip.Ip), ip.MessageError, ip.Ip)
 	}
 }
 

--- a/ip/iputil_test.go
+++ b/ip/iputil_test.go
@@ -92,8 +92,6 @@ func TestIsPort(t *testing.T) {
 
 func TestIsIPv4(t *testing.T) {
 	require.True(t, IsIPv4("127.0.0.1"), "valid ipv4 address not recognized")
-	require.True(t, IsIPv4("127.1"), "valid ipv4 address not recognized")
-	require.True(t, IsIPv4("127.1.1"), "valid ipv4 address not recognized")
 	require.False(t, IsIPv4("2001:0db8:85a3:0000:0000:8a2e:0370:7334"), "ipv6 address recognized as valid")
 }
 

--- a/ip/iputil_test.go
+++ b/ip/iputil_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestIsIP(t *testing.T) {
+func TestIsIPv4Short(t *testing.T) {
 	type test struct {
 		Ip           string
 		Expected     bool
@@ -15,35 +15,25 @@ func TestIsIP(t *testing.T) {
 
 	validIpsTest := []test{
 		{
-			Ip:           "35.1",
+			Ip:           "192.168.1",
 			Expected:     true,
 			MessageError: "valid ip not recognized",
 		},
-		{
-			Ip:           "35.1.124",
-			Expected:     true,
-			MessageError: "valid ip not recognized",
-		},
-		{
-			Ip:           "35.1.1.124",
-			Expected:     true,
-			MessageError: "valid ip not recognized",
-		},
-		{
-			Ip:           "127.1",
-			Expected:     true,
-			MessageError: "valid ip not recognized",
-		},
-		{
-			Ip:           "127.1.1",
-			Expected:     true,
-			MessageError: "valid ip not recognized",
-		},
-		{
-			Ip:           "::1",
-			Expected:     true,
-			MessageError: "valid ip not recognized",
-		},
+	}
+
+	for _, ip := range validIpsTest {
+		require.Equal(t, ip.Expected, IsIPv4(ip.Ip), ip.MessageError, ip.Ip)
+	}
+}
+
+func TestIsIPv6Shot(t *testing.T) {
+	type test struct {
+		Ip           string
+		Expected     bool
+		MessageError string
+	}
+
+	validIpsTest := []test{
 		{
 			Ip:           "001:0db8::1",
 			Expected:     true,
@@ -64,20 +54,10 @@ func TestIsIP(t *testing.T) {
 			Expected:     true,
 			MessageError: "valid ip not recognized",
 		},
-		{
-			Ip:           "127.0.0.1/24",
-			Expected:     false,
-			MessageError: "cidr reconized as ip",
-		},
-		{
-			Ip:           "test",
-			Expected:     false,
-			MessageError: "string reconized as ip",
-		},
 	}
 
 	for _, ip := range validIpsTest {
-		require.Equal(t, ip.Expected, IsIP(ip.Ip), ip.MessageError)
+		require.Equal(t, ip.Expected, IsIPv6(ip.Ip), ip.MessageError, ip.Ip)
 	}
 }
 

--- a/ip/iputil_test.go
+++ b/ip/iputil_test.go
@@ -15,6 +15,16 @@ func TestIsIPv4Short(t *testing.T) {
 
 	validIpsTest := []test{
 		{
+			Ip:           "35.1",
+			Expected:     true,
+			MessageError: "valid ip not recognized",
+		},
+		{
+			Ip:           "35.1.124",
+			Expected:     true,
+			MessageError: "valid ip not recognized",
+		},
+		{
 			Ip:           "192.168.1",
 			Expected:     true,
 			MessageError: "valid ip not recognized",


### PR DESCRIPTION
```go
ValidiIpTests := []string{
	"35.1",
	"35.1.124",
	"35.1.1.124",
	"127.1",
	"127.1.1",
	"::1",
	"001:0db8::1",
	"::a00:27ff:fef3:7d56",
	"fe80::a00:27ff:fef3:7d56",
	"2607:f0d0:1002:0051:0000:0000:0000:0004",
}
```