### PR TITLE
Remove impossible unix buildconstraint

### DIFF
--- a/permission/permission_linux.go
+++ b/permission/permission_linux.go
@@ -1,4 +1,4 @@
-//go:build linux || unix
+//go:build linux
 
 package permissionutil
 


### PR DESCRIPTION
Given the filename with the `_GOOS` suffix this file can be build only on `linux` (most other Unix-es should be already handled via `permission_{darwin,linux}.go`).

NFCI.
