### PR TITLE
update util improvements

### DIFF
--- a/update/gh.go
+++ b/update/gh.go
@@ -27,11 +27,12 @@ var (
 
 // GHReleaseDownloader fetches and reads release of a gh repo
 type GHReleaseDownloader struct {
-	ToolName  string // we assume toolname and ToolName are always same
-	Format    AssetFormat
-	AssetID   int
-	AssetName string
-	client    *github.Client
+	ToolName   string // we assume toolname and ToolName are always same
+	Format     AssetFormat
+	AssetID    int
+	AssetName  string
+	client     *github.Client
+	httpClient *http.Client
 }
 
 // NewghReleaseDownloader instance
@@ -43,8 +44,7 @@ func NewghReleaseDownloader(toolName string) *GHReleaseDownloader {
 	if token := os.Getenv("GITHUB_TOKEN"); token != "" {
 		httpClient = oauth2.NewClient(context.Background(), oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token}))
 	}
- 
-	ghrd := GHReleaseDownloader{client: github.NewClient(DefaultHttpClient), ToolName: toolName}
+	ghrd := GHReleaseDownloader{client: github.NewClient(httpClient), ToolName: toolName, httpClient: httpClient}
 
 	if ghrd.AssetName == "" && GHAssetName != "" {
 		ghrd.AssetName = GHAssetName

--- a/update/gh.go
+++ b/update/gh.go
@@ -38,8 +38,7 @@ type GHReleaseDownloader struct {
 // NewghReleaseDownloader instance
 func NewghReleaseDownloader(toolName string) *GHReleaseDownloader {
 	httpClient := &http.Client{
-		Timeout:   DownloadUpdateTimeout,
-		Transport: &http.Transport{},
+		Timeout: DownloadUpdateTimeout,
 	}
 	if token := os.Getenv("GITHUB_TOKEN"); token != "" {
 		httpClient = oauth2.NewClient(context.Background(), oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token}))
@@ -119,7 +118,7 @@ func (d *GHReleaseDownloader) DownloadAssetFromID() (*bytes.Buffer, error) {
 	if err != nil {
 		return nil, errorutil.NewWithErr(err).Msgf("failed to download release asset")
 	}
-	if resp.StatusCode != 200 {
+	if resp.StatusCode != http.StatusOK {
 		return nil, errorutil.New("something went wrong got %v while downloading asset, expected status 200", resp.StatusCode)
 	}
 	if resp.Body == nil {

--- a/update/update.go
+++ b/update/update.go
@@ -105,11 +105,6 @@ func GetVersionCheckCallback(toolName string) func() (string, error) {
 			DefaultHttpClient = http.DefaultClient
 			DefaultHttpClient.Timeout = VersionCheckTimeout
 		}
-		// allow cert validation in version check but not in update
-		DefaultHttpClient.Transport = &http.Transport{
-			Proxy:           http.ProxyFromEnvironment,
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-		}
 		resp, err := DefaultHttpClient.Get(updateURL)
 		if err != nil {
 			return "", errorutil.NewWithErr(err).Msgf("http Get %v failed", updateURL).WithTag("updater")

--- a/update/update.go
+++ b/update/update.go
@@ -31,7 +31,8 @@ var (
 	HideProgressBar       = false
 	VersionCheckTimeout   = time.Duration(5) * time.Second
 	DownloadUpdateTimeout = time.Duration(30) * time.Second
-	DefaultHttpClient     *http.Client
+	// Note: DefaultHttpClient is only used in VersionCheck Callback
+	DefaultHttpClient *http.Client
 )
 
 // GetUpdateToolCallback returns a callback function
@@ -147,7 +148,8 @@ func init() {
 	DefaultHttpClient = &http.Client{
 		Timeout: VersionCheckTimeout,
 		Transport: &http.Transport{
-			Proxy: http.ProxyFromEnvironment,
+			Proxy:           http.ProxyFromEnvironment,
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 		},
 	}
 }


### PR DESCRIPTION
### Proposed Changes

> * fix `GetUpdateCallback` not using http timeout
> * Disable proxying upgrade traffic (i.e github get latest release , download binary etc)

- closes #103 