### PR TITLE
fix panic on err and version empty

### DIFF
--- a/update/update.go
+++ b/update/update.go
@@ -135,7 +135,11 @@ func GetToolVersionCallback(toolName, version string) func() (string, error) {
 			return "", errorutil.NewWithErr(err).Msgf("failed to unmarshal %v", string(body)).WithTag("updater")
 		}
 		if toolDetails.Version == "" {
-			return "", errorutil.NewWithErr(err).Msgf("something went wrong, expected version string but got empty string for GET `%v`", updateURL)
+			msg := fmt.Sprintf("something went wrong, expected version string but got empty string for GET `%v`", updateURL)
+			if err == nil {
+				return "", errorutil.New(msg)
+			}
+			return "", errorutil.NewWithErr(err).Msgf(msg)
 		}
 		return toolDetails.Version, nil
 	}

--- a/update/update.go
+++ b/update/update.go
@@ -135,7 +135,7 @@ func GetToolVersionCallback(toolName, version string) func() (string, error) {
 			return "", errorutil.NewWithErr(err).Msgf("failed to unmarshal %v", string(body)).WithTag("updater")
 		}
 		if toolDetails.Version == "" {
-			msg := fmt.Sprintf("something went wrong, expected version string but got empty string for GET `%v`", updateURL)
+			msg := fmt.Sprintf("something went wrong, expected version string but got empty string for GET `%v` response `%v`", updateURL, string(body))
 			if err == nil {
 				return "", errorutil.New(msg)
 			}


### PR DESCRIPTION
`GetToolVersionCallback()` panic when err is nil and version is empty.
<details><summary>Example to reproduce</summary>
<p>

```go
package main

import (
	"fmt"
	updateutils "github.com/projectdiscovery/utils/update"

)

func main() {
	latestVersion, err := updateutils.GetToolVersionCallback("cdncheck", "0.0.3")()
	fmt.Printf("err: %v\n, lv: %v\n", err, latestVersion)
}

```

</p>
</details>
