### PR TITLE
fix removing semicolon while decoding params

### DIFF
--- a/url/rawparam.go
+++ b/url/rawparam.go
@@ -132,7 +132,9 @@ func (p Params) Decode(raw string) {
 			if AllowLegacySeperator {
 				arr = append(arr, tbuff.String())
 				tbuff.Reset()
+				continue
 			}
+			tbuff.WriteRune(v)
 		default:
 			tbuff.WriteRune(v)
 		}

--- a/url/rawparam_test.go
+++ b/url/rawparam_test.go
@@ -103,17 +103,17 @@ func TestURLEncode(t *testing.T) {
 
 func TestURLDecode(t *testing.T) {
 	testcases := []struct {
-		raw      string
+		url      string
 		Expected Params
 	}{
 		{
 			"/ctc/servlet/ConfigServlet?param=com.sap.ctc.util.FileSystemConfig;EXECUTE_CMD;CMDLINE=tasklist",
-			Params{"/ctc/servlet/ConfigServlet?param": []string{"com.sap.ctc.util.FileSystemConfig;EXECUTE_CMD;CMDLINE=tasklist"}},
+			Params{"param": []string{"com.sap.ctc.util.FileSystemConfig;EXECUTE_CMD;CMDLINE=tasklist"}},
 		},
 	}
 	for _, v := range testcases {
-		params := make(Params)
-		params.Decode(v.raw)
-		require.Equalf(t, v.Expected, params, "failed to decode params %v expected %v got %v", v.raw, v.Expected, params)
+		parsed, err := Parse(v.url)
+		require.Nilf(t, err, "failed to parse url %v", v.url)
+		require.Equalf(t, v.Expected, parsed.Query(), "failed to decode params in url %v expected %v got %v", v.url, v.Expected, parsed.Query())
 	}
 }

--- a/url/rawparam_test.go
+++ b/url/rawparam_test.go
@@ -100,3 +100,20 @@ func TestURLEncode(t *testing.T) {
 		require.Equalf(t, expected, got, "url encoding mismatch for non-printable char with ascii val:%v", r)
 	}
 }
+
+func TestURLDecode(t *testing.T) {
+	testcases := []struct {
+		raw      string
+		Expected Params
+	}{
+		{
+			"/ctc/servlet/ConfigServlet?param=com.sap.ctc.util.FileSystemConfig;EXECUTE_CMD;CMDLINE=tasklist",
+			Params{"/ctc/servlet/ConfigServlet?param": []string{"com.sap.ctc.util.FileSystemConfig;EXECUTE_CMD;CMDLINE=tasklist"}},
+		},
+	}
+	for _, v := range testcases {
+		params := make(Params)
+		params.Decode(v.raw)
+		require.Equalf(t, v.Expected, params, "failed to decode params %v expected %v got %v", v.raw, v.Expected, params)
+	}
+}


### PR DESCRIPTION
Failed to decode params when request query params has semicolons.

Ex: `/ctc/servlet/ConfigServlet?param=com.sap.ctc.util.FileSystemConfig;EXECUTE_CMD;CMDLINE=tasklist`

__Current Decoded Param__:
```
com.sap.ctc.util.FileSystemConfigEXECUTE_CMDCMDLINE=tasklist
```
__Expected Decoded Param__:
```
com.sap.ctc.util.FileSystemConfig;EXECUTE_CMD;CMDLINE=tasklist
```