### PR TITLE
Add file size converter

### DIFF
--- a/file/file.go
+++ b/file/file.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -485,4 +486,36 @@ func substituteEnvVars(line string) string {
 		}
 	}
 	return line
+}
+
+// FileSizeToByteLen converts a file size with units(kb, mb, gb, tb) to byte length
+// e.g. 1kb -> 1024
+// If no unit is provided, it will fallback to mb. e.g: '2' will be converted to 2097152.
+func FileSizeToByteLen(fileSize string) (int, error) {
+	fileSize = strings.ToLower(fileSize)
+	// default to mb
+	if size, err := strconv.Atoi(fileSize); err == nil {
+		return size * 1024 * 1024, nil
+	}
+	if len(fileSize) < 3 {
+		return 0, errors.New("invalid size value")
+	}
+	sizeUnit := fileSize[len(fileSize)-2:]
+	size, err := strconv.Atoi(fileSize[:len(fileSize)-2])
+	if err != nil {
+		return 0, errors.New("parse error: " + err.Error())
+	}
+	if size < 0 {
+		return 0, errors.New("size cannot be negative")
+	}
+	if strings.EqualFold(sizeUnit, "kb") {
+		return size * 1024, nil
+	} else if strings.EqualFold(sizeUnit, "mb") {
+		return size * 1024 * 1024, nil
+	} else if strings.EqualFold(sizeUnit, "gb") {
+		return size * 1024 * 1024 * 1024, nil
+	} else if strings.EqualFold(sizeUnit, "tb") {
+		return size * 1024 * 1024 * 1024 * 1024, nil
+	}
+	return 0, errors.New("unsupported size unit")
 }

--- a/file/file_test.go
+++ b/file/file_test.go
@@ -521,3 +521,21 @@ func TestSubstituteConfigFromEnvVars(t *testing.T) {
 		require.Equal(t, expectedFileContentLines[i], gotFileContentLines[i], "lines in config don't match")
 	}
 }
+
+func TestFileSizeToByteLen(t *testing.T) {
+	byteLen, err := FileSizeToByteLen("2kb")
+	require.Nil(t, err, "couldn't convert file size to byte len: %s", err)
+	require.Equal(t, int(2048), byteLen)
+
+	byteLen, err = FileSizeToByteLen("2mb")
+	require.Nil(t, err, "couldn't convert file size to byte len: %s", err)
+	require.Equal(t, int(2097152), byteLen)
+
+	byteLen, err = FileSizeToByteLen("2")
+	require.Nil(t, err, "couldn't convert file size to byte len: %s", err)
+	require.Equal(t, int(2097152), byteLen)
+
+	_, err = FileSizeToByteLen("2kilobytes")
+	require.NotNil(t, err, "shouldn't convert file size to byte len: %s", err)
+	require.ErrorContains(t, err, "parse error")
+}


### PR DESCRIPTION
Description:
- Add helper function to convert fileSize with units to bytes length
- For example, '2kb' will be converted to 2048.
- If no unit is provided, it will fallback to mb. e.g: '2' will be converted to 2097152.