### PR TITLE
support days unit while parsing time string

### DIFF
--- a/permission/permission_win.go
+++ b/permission/permission_win.go
@@ -26,7 +26,7 @@ func checkCurrentUserRoot() (bool, error) {
 		return false, err
 	}
 
-	defer windows.FreeSid(sid)
+	defer func() { _ = windows.FreeSid(sid) }()
 
 	// This appears to cast a null pointer so I'm not sure why this
 	// works, but this guy says it does and it Works for Me™:

--- a/time/timeutil.go
+++ b/time/timeutil.go
@@ -3,6 +3,7 @@ package timeutil
 import (
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -54,4 +55,22 @@ func ParseUnixTimestamp(s string) (time.Time, error) {
 		return time.Time{}, err
 	}
 	return time.Unix(i, 0), nil
+}
+
+// ParseDuration is similar to time.ParseDuration but also supports days unit
+// if the unit is omitted, it defaults to seconds
+func ParseDuration(s string) (time.Duration, error) {
+	s = strings.ToLower(s)
+	// default to sec
+	if _, err := strconv.Atoi(s); err == nil {
+		s = s + "s"
+	}
+	// parse days unit as hours
+	if strings.HasSuffix(s, "d") {
+		s = strings.TrimSuffix(s, "d")
+		if days, err := strconv.Atoi(s); err == nil {
+			s = strconv.Itoa(days*24) + "h"
+		}
+	}
+	return time.ParseDuration(s)
 }

--- a/time/timeutil_test.go
+++ b/time/timeutil_test.go
@@ -22,3 +22,13 @@ func TestMsToTime(t *testing.T) {
 func TestSToTime(t *testing.T) {
 	// TBD in chaos + bbsh
 }
+
+func TestParseDuration(t *testing.T) {
+	tt, err := ParseDuration("2d")
+	require.Nil(t, err, "couldn't parse duration")
+	require.Equal(t, time.Hour*24*2, tt, "times don't match")
+
+	tt, err = ParseDuration("2")
+	require.Nil(t, err, "couldn't parse duration")
+	require.Equal(t, time.Second*2, tt, "times don't match")
+}


### PR DESCRIPTION
`time.ParseDuration` valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
  Also support:
  days unit => ex: "2d" => 2*24+"h"
  default to sec => ex: "10" => 10s