### PR TITLE
Adding fallback for purego unsupported archs

### DIFF
--- a/syscallutil/syscall_unix.go
+++ b/syscallutil/syscall_unix.go
@@ -1,4 +1,4 @@
-//go:build (darwin || linux) && !386
+//go:build (darwin || linux) && !(386 || arm_6)
 
 package syscallutil
 

--- a/syscallutil/syscall_unix.go
+++ b/syscallutil/syscall_unix.go
@@ -1,4 +1,4 @@
-//go:build (darwin || linux) && !(386 || arm_6)
+//go:build (darwin || linux) && !(386 || arm)
 
 package syscallutil
 

--- a/syscallutil/syscall_unix_386.go
+++ b/syscallutil/syscall_unix_386.go
@@ -1,9 +1,9 @@
-//go:build (darwin || linux) && !386
+//go:build (darwin || linux) && 386
 
 package syscallutil
 
 import "github.com/ebitengine/purego"
 
 func loadLibrary(name string) (uintptr, error) {
-	return purego.Dlopen(name, purego.RTLD_NOW|purego.RTLD_GLOBAL)
+	return -1, errors.New("not implemented")
 }

--- a/syscallutil/syscall_unix_others.go
+++ b/syscallutil/syscall_unix_others.go
@@ -2,8 +2,8 @@
 
 package syscallutil
 
-import "github.com/ebitengine/purego"
+import "errors"
 
 func loadLibrary(name string) (uintptr, error) {
-	return -1, errors.New("not implemented")
+	return 0, errors.New("not implemented")
 }

--- a/syscallutil/syscall_unix_others.go
+++ b/syscallutil/syscall_unix_others.go
@@ -1,4 +1,4 @@
-//go:build (darwin || linux) && (386 || arm_6)
+//go:build (darwin || linux) && (386 || arm)
 
 package syscallutil
 

--- a/syscallutil/syscall_unix_others.go
+++ b/syscallutil/syscall_unix_others.go
@@ -1,4 +1,4 @@
-//go:build (darwin || linux) && 386
+//go:build (darwin || linux) && (386 || arm_6)
 
 package syscallutil
 


### PR DESCRIPTION
purego doesn't expose valid bindings for unix 386 and darwin, this PR implements a fallback with explicit error return