### PR TITLE
add FileExistsIn func

### DIFF
--- a/file/file.go
+++ b/file/file.go
@@ -10,6 +10,7 @@ import (
 	"io/fs"
 	"net/http"
 	"os"
+	"path"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -32,6 +33,29 @@ func FileExists(filename string) bool {
 		return false
 	}
 	return !info.IsDir()
+}
+
+// FileExistsIn checks if the file exists in the allowed paths
+func FileExistsIn(file string, allowedPaths ...string) bool {
+	fileAbsPath, err := filepath.Abs(file)
+	if err != nil {
+		return false
+	}
+
+	for _, allowedPath := range allowedPaths {
+		allowedAbsPath, err := filepath.Abs(allowedPath)
+		if err != nil {
+			return false
+		}
+		allowedDirPath := allowedAbsPath
+		if path.Ext(allowedAbsPath) != "" {
+			allowedDirPath = filepath.Dir(allowedAbsPath)
+		}
+		if strings.HasPrefix(fileAbsPath, allowedDirPath) && FileExists(fileAbsPath) {
+			return true
+		}
+	}
+	return false
 }
 
 // FolderExists checks if the folder exists

--- a/file/file_test.go
+++ b/file/file_test.go
@@ -581,3 +581,39 @@ func TestOpenOrCreateFile(t *testing.T) {
 		require.Error(t, err)
 	})
 }
+
+func TestFileExistsIn(t *testing.T) {
+	tempDir := t.TempDir()
+	anotherTempDir := t.TempDir()
+	tempFile := filepath.Join(tempDir, "file.txt")
+	os.WriteFile(tempFile, []byte("content"), 0644)
+
+	tests := []struct {
+		name          string
+		file          string
+		allowedFiles  []string
+		expectedExist bool
+	}{
+		{
+			name:          "file exists in allowed directory",
+			file:          tempFile,
+			allowedFiles:  []string{filepath.Join(tempDir, "tempfile.txt")},
+			expectedExist: true,
+		},
+		{
+			name:          "file does not exist in allowed directory",
+			file:          tempFile,
+			allowedFiles:  []string{anotherTempDir},
+			expectedExist: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			exists := FileExistsIn(tc.file, tc.allowedFiles...)
+			if exists != tc.expectedExist {
+				t.Errorf("expected existence to be %v but got %v", tc.expectedExist, exists)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #212.

Note: This isn't an exact implementation. For example, the `allowedPaths` is mandatory; otherwise, the func will always return false. Another one, instead of creating a list of a simplified list of paths, I decided to allow duplicate checks, for example, func will check for both of the following paths, {"/home/user/file1.txt", "home/user/file2.txt"}.