### PR TITLE
add SyncLockMap ctor func

### DIFF
--- a/maps/synclock_map.go
+++ b/maps/synclock_map.go
@@ -18,16 +18,28 @@ type SyncLockMap[K, V comparable] struct {
 	Map      Map[K, V]
 }
 
+type SyncLockMapOption[K, V comparable] func(slm *SyncLockMap[K, V])
+
+func WithMap[K, V comparable](m Map[K, V]) SyncLockMapOption[K, V] {
+	return func(slm *SyncLockMap[K, V]) {
+		slm.Map = m
+	}
+}
+
 // NewSyncLockMap creates a new SyncLockMap.
 // If an existing map is provided, it is used; otherwise, a new map is created.
-func NewSyncLockMap[K, V comparable](m Map[K, V]) *SyncLockMap[K, V] {
-	if m == nil {
-		m = make(Map[K, V])
+func NewSyncLockMap[K, V comparable](options ...SyncLockMapOption[K, V]) *SyncLockMap[K, V] {
+	slm := &SyncLockMap[K, V]{}
+
+	for _, option := range options {
+		option(slm)
 	}
 
-	return &SyncLockMap[K, V]{
-		Map: m,
+	if slm.Map == nil {
+		slm.Map = make(Map[K, V])
 	}
+
+	return slm
 }
 
 // Lock the current map to read-only mode

--- a/maps/synclock_map.go
+++ b/maps/synclock_map.go
@@ -18,6 +18,18 @@ type SyncLockMap[K, V comparable] struct {
 	Map      Map[K, V]
 }
 
+// NewSyncLockMap creates a new SyncLockMap.
+// If an existing map is provided, it is used; otherwise, a new map is created.
+func NewSyncLockMap[K, V comparable](m Map[K, V]) *SyncLockMap[K, V] {
+	if m == nil {
+		m = make(Map[K, V])
+	}
+
+	return &SyncLockMap[K, V]{
+		Map: m,
+	}
+}
+
 // Lock the current map to read-only mode
 func (s *SyncLockMap[K, V]) Lock() {
 	s.ReadOnly.Store(true)

--- a/maps/synclock_map_test.go
+++ b/maps/synclock_map_test.go
@@ -31,8 +31,8 @@ func TestSyncLockMap(t *testing.T) {
 
 	t.Run("Test NewSyncLockMap without map", func(t *testing.T) {
 		m := NewSyncLockMap[string, string](nil)
-		m.Set("key1", "value1")
-		m.Set("key2", "value2")
+		_ = m.Set("key1", "value1")
+		_ = m.Set("key2", "value2")
 
 		if !m.Has("key1") || !m.Has("key2") {
 			t.Error("couldn't init SyncLockMap with NewSyncLockMap")

--- a/maps/synclock_map_test.go
+++ b/maps/synclock_map_test.go
@@ -18,6 +18,27 @@ func TestSyncLockMap(t *testing.T) {
 		},
 	}
 
+	t.Run("Test NewSyncLockMap with map ", func(t *testing.T) {
+		m := NewSyncLockMap[string, string](Map[string, string]{
+			"key1": "value1",
+			"key2": "value2",
+		})
+
+		if !m.Has("key1") || !m.Has("key2") {
+			t.Error("couldn't init SyncLockMap with NewSyncLockMap")
+		}
+	})
+
+	t.Run("Test NewSyncLockMap without map", func(t *testing.T) {
+		m := NewSyncLockMap[string, string](nil)
+		m.Set("key1", "value1")
+		m.Set("key2", "value2")
+
+		if !m.Has("key1") || !m.Has("key2") {
+			t.Error("couldn't init SyncLockMap with NewSyncLockMap")
+		}
+	})
+
 	t.Run("Test lock", func(t *testing.T) {
 		m.Lock()
 		if m.ReadOnly.Load() != true {

--- a/maps/synclock_map_test.go
+++ b/maps/synclock_map_test.go
@@ -19,10 +19,10 @@ func TestSyncLockMap(t *testing.T) {
 	}
 
 	t.Run("Test NewSyncLockMap with map ", func(t *testing.T) {
-		m := NewSyncLockMap[string, string](Map[string, string]{
+		m := NewSyncLockMap[string, string](WithMap(Map[string, string]{
 			"key1": "value1",
 			"key2": "value2",
-		})
+		}))
 
 		if !m.Has("key1") || !m.Has("key2") {
 			t.Error("couldn't init SyncLockMap with NewSyncLockMap")
@@ -30,7 +30,7 @@ func TestSyncLockMap(t *testing.T) {
 	})
 
 	t.Run("Test NewSyncLockMap without map", func(t *testing.T) {
-		m := NewSyncLockMap[string, string](nil)
+		m := NewSyncLockMap[string, string]()
 		_ = m.Set("key1", "value1")
 		_ = m.Set("key2", "value2")
 


### PR DESCRIPTION
## Proposed changes
`SyncLockMap` turned out to be very useful as LOC reduction strategy since it can replace any builtin map that requires a mutex. Actually the structure must be initialized with some long boilerplate code as follows:
```go
m := &SyncLockMap[string, string]{
	Map: make(map[string, string]),
}
```
The task is about implementing a `NewSyncLockMap[K,V](...)` function that returns new `SyncLockMap` with the underlying Map initialized. Closes #226.