### PR TITLE
add default permissions

### DIFF
--- a/permission/permission_file.go
+++ b/permission/permission_file.go
@@ -45,6 +45,12 @@ const (
 	AllExecute          = UserExecute | GroupExecute | OtherExecute
 	AllReadWrite        = AllRead | AllWrite
 	AllReadWriteExecute = AllReadWrite | AllExecute
+
+	// Default File/Folder Permissions
+	ConfigFolderPermission = UserReadWriteExecute
+	ConfigFilePermission   = UserReadWrite
+	BinaryPermission       = UserRead | UserExecute
+	TempFilePermission     = UserReadWrite
 )
 
 // UpdateFilePerm modifies the permissions of the given file.


### PR DESCRIPTION
## Proposed changes
Define a standard set of default file permissions on creation/update to use globally for all tools, in [utils/permissions](https://github.com/projectdiscovery/utils/blob/main/permission/permission_file.go). Closes #225.