### PR TITLE
improve home folder detection

### DIFF
--- a/folder/folderutil.go
+++ b/folder/folderutil.go
@@ -159,8 +159,16 @@ func HomeDirOrDefault(defaultDirectory string) string {
 
 // isWritable checks if a path is writable.
 func isWritable(path string) bool {
-	hasPermission, _ := fileutil.HasPermission(path, os.O_WRONLY)
-	return hasPermission
+	info, err := os.Stat(path)
+	if err != nil || !info.IsDir() {
+		return false
+	}
+	tmpfile, err := os.CreateTemp(path, "test")
+	if err != nil {
+		return false
+	}
+	defer os.Remove(tmpfile.Name())
+	return true
 }
 
 // UserConfigDirOrDefault returns the user config directory or defaultConfigDir in case of error

--- a/folder/folderutil.go
+++ b/folder/folderutil.go
@@ -148,12 +148,11 @@ func agnosticSplit(path string) (parts []string) {
 // HomeDirOrDefault tries to obtain the user's home directory and
 // returns the default if it cannot be obtained.
 func HomeDirOrDefault(defaultDirectory string) string {
-	home, err := user.Current()
-	if err == nil && isWritable(home.HomeDir) {
-		return home.HomeDir
+	if user, err := user.Current(); err == nil && isWritable(user.HomeDir) {
+		return user.HomeDir
 	}
-	if homeEnv, ok := os.LookupEnv("HOME"); ok && isWritable(homeEnv) {
-		return homeEnv
+	if homeDir, err := os.UserHomeDir(); err == nil && isWritable(homeDir) {
+		return homeDir
 	}
 	return defaultDirectory
 }

--- a/folder/folderutil.go
+++ b/folder/folderutil.go
@@ -159,10 +159,10 @@ func HomeDirOrDefault(defaultDirectory string) string {
 
 // isWritable checks if a path is writable.
 func isWritable(path string) bool {
-	info, err := os.Stat(path)
-	if err != nil || !info.IsDir() {
+	if !fileutil.FolderExists(path) {
 		return false
 	}
+
 	tmpfile, err := os.CreateTemp(path, "test")
 	if err != nil {
 		return false

--- a/folder/folderutil.go
+++ b/folder/folderutil.go
@@ -148,17 +148,19 @@ func agnosticSplit(path string) (parts []string) {
 // HomeDirOrDefault tries to obtain the user's home directory and
 // returns the default if it cannot be obtained.
 func HomeDirOrDefault(defaultDirectory string) string {
-	if user, err := user.Current(); err == nil && isWritable(user.HomeDir) {
+	if user, err := user.Current(); err == nil && IsWritable(user.HomeDir) {
 		return user.HomeDir
 	}
-	if homeDir, err := os.UserHomeDir(); err == nil && isWritable(homeDir) {
+	if homeDir, err := os.UserHomeDir(); err == nil && IsWritable(homeDir) {
 		return homeDir
 	}
 	return defaultDirectory
 }
 
-// isWritable checks if a path is writable.
-func isWritable(path string) bool {
+// IsWritable checks if a path is writable by attempting to create a temporary file.
+// Note: It's recommended to minimize the use of this function because it involves file creation.
+// If performance is a concern, consider declaring a global variable in the module using this and initialize it once.
+func IsWritable(path string) bool {
 	if !fileutil.FolderExists(path) {
 		return false
 	}

--- a/folder/folderutil.go
+++ b/folder/folderutil.go
@@ -145,13 +145,23 @@ func agnosticSplit(path string) (parts []string) {
 	return
 }
 
-// HomeDirectory returns the home directory or defaultDirectory in case of error
+// HomeDirOrDefault tries to obtain the user's home directory and
+// returns the default if it cannot be obtained.
 func HomeDirOrDefault(defaultDirectory string) string {
-	usr, err := user.Current()
-	if err != nil {
-		return defaultDirectory
+	home, err := user.Current()
+	if err == nil && isWritable(home.HomeDir) {
+		return home.HomeDir
 	}
-	return usr.HomeDir
+	if homeEnv, ok := os.LookupEnv("HOME"); ok && isWritable(homeEnv) {
+		return homeEnv
+	}
+	return defaultDirectory
+}
+
+// isWritable checks if a path is writable.
+func isWritable(path string) bool {
+	hasPermission, _ := fileutil.HasPermission(path, os.O_WRONLY)
+	return hasPermission
 }
 
 // UserConfigDirOrDefault returns the user config directory or defaultConfigDir in case of error

--- a/folder/folderutil_test.go
+++ b/folder/folderutil_test.go
@@ -111,3 +111,38 @@ func TestSyncDirectory(t *testing.T) {
 		assert.True(t, fileutil.FolderExists(sourceDir))
 	})
 }
+
+func TestIsWritable(t *testing.T) {
+	t.Run("Test writable directory", func(t *testing.T) {
+		tempDir, err := os.MkdirTemp("", "test-dir")
+		assert.NoError(t, err)
+		defer os.RemoveAll(tempDir)
+
+		assert.True(t, IsWritable(tempDir), "expected directory to be writable")
+	})
+
+	t.Run("Test non-existent directory", func(t *testing.T) {
+		nonExistentDir := "/path/to/non/existent/dir"
+		assert.False(t, IsWritable(nonExistentDir), "expected directory to not be writable")
+	})
+
+	t.Run("Test non-writable directory", func(t *testing.T) {
+		nonWritableDir, err := os.MkdirTemp("", "non-writable-dir")
+		assert.NoError(t, err)
+		defer os.RemoveAll(nonWritableDir)
+
+		// Make the directory non-writable.
+		err = os.Chmod(nonWritableDir, 0555)
+		assert.NoError(t, err)
+
+		assert.False(t, IsWritable(nonWritableDir), "expected directory to not be writable")
+	})
+
+	t.Run("Test with a file instead of a directory", func(t *testing.T) {
+		tempFile, err := os.CreateTemp("", "test-file")
+		assert.NoError(t, err)
+		defer os.Remove(tempFile.Name())
+
+		assert.False(t, IsWritable(tempFile.Name()), "expected file to not be considered a writable directory")
+	})
+}

--- a/folder/folderutil_test.go
+++ b/folder/folderutil_test.go
@@ -132,7 +132,7 @@ func TestIsWritable(t *testing.T) {
 		defer os.RemoveAll(nonWritableDir)
 
 		// Make the directory non-writable.
-		err = os.Chmod(nonWritableDir, 0555)
+		err = os.Chmod(nonWritableDir, 0400)
 		assert.NoError(t, err)
 
 		assert.False(t, IsWritable(nonWritableDir), "expected directory to not be writable")

--- a/folder/folderutil_test.go
+++ b/folder/folderutil_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	fileutil "github.com/projectdiscovery/utils/file"
+	osutils "github.com/projectdiscovery/utils/os"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -127,6 +128,12 @@ func TestIsWritable(t *testing.T) {
 	})
 
 	t.Run("Test non-writable directory", func(t *testing.T) {
+		// on windows bitsets are applied only to files
+		// https://github.com/golang/go/issues/35042
+		if osutils.IsWindows() {
+			return
+		}
+
 		nonWritableDir := "non-writable-dir"
 		err := os.Mkdir(nonWritableDir, 0400)
 		assert.NoError(t, err)

--- a/folder/folderutil_test.go
+++ b/folder/folderutil_test.go
@@ -127,7 +127,8 @@ func TestIsWritable(t *testing.T) {
 	})
 
 	t.Run("Test non-writable directory", func(t *testing.T) {
-		nonWritableDir, err := os.MkdirTemp("", "non-writable-dir")
+		nonWritableDir := "non-writable-dir"
+		err := os.Mkdir(nonWritableDir, 0400)
 		assert.NoError(t, err)
 		defer os.RemoveAll(nonWritableDir)
 


### PR DESCRIPTION
### Proposal
With reference to https://github.com/projectdiscovery/subfinder/pull/903#issuecomment-1671671719 the task is about investigating the addition of `os.UserHomeDir()` to `folderutils.HomeDirOrDefault`. The actual behavior is obtaining the home directory via system call from the `passwd` file (linux|osx), anyway, in certain conditions (ex. lambda vms) this mechanism is not reliable and other methods like obtaining the home folder from the `$HOME` env variable might be preferred.

Possible approach: starting from the assumption that the user home folder is writeable, we can default to the value obtained via system call, and if the folder is read-only, we fallback to env variable.

Closes #237.