### PR TITLE
add more unit test for url fragment parsing

### DIFF
--- a/url/url.go
+++ b/url/url.go
@@ -234,8 +234,6 @@ func ParseURL(inputURL string, unsafe bool) (*URL, error) {
 		Params:   NewOrderedParams(),
 	}
 	u.fetchParams()
-	// filter out fragments and parameters only then parse path
-	inputURL = u.Original
 	if inputURL == "" {
 		return nil, errorutil.NewWithTag("urlutil", "failed to parse url got empty input")
 	}

--- a/url/url.go
+++ b/url/url.go
@@ -234,6 +234,10 @@ func ParseURL(inputURL string, unsafe bool) (*URL, error) {
 		Params:   NewOrderedParams(),
 	}
 	u.fetchParams()
+	// filter out fragments and parameters only then parse path
+	// we use u.Original because u.fetchParams() parses fragments and parameters
+	// from u.Original (this is done to preserve query order in params and other edgecases)
+	inputURL = u.Original
 	if inputURL == "" {
 		return nil, errorutil.NewWithTag("urlutil", "failed to parse url got empty input")
 	}

--- a/url/url_test.go
+++ b/url/url_test.go
@@ -118,13 +118,15 @@ func TestParseRelativePath(t *testing.T) {
 	}
 }
 
-func TestParseFragment(t *testing.T) {
+func TestParseFragmentRelativePath(t *testing.T) {
 	testcases := []struct {
 		inputURL         string
 		unsafe           bool
 		expectedFragment string
 	}{
-		{"https://admin?param=value#highlight", false, "highlight"},
+		{"/?param=value#highlight", false, "highlight"},
+		{"/somepath/#highlight", true, "highlight"},
+		{"/somepath/?with=param#highlight", false, "highlight"},
 	}
 
 	for _, v := range testcases {
@@ -140,12 +142,29 @@ func TestParseParam(t *testing.T) {
 		unsafe        bool
 		expectedParam string
 	}{
-		{"https://admin?param=value#highlight", false, "param=value"},
+		{"https://scanme.sh/?param=value#highlight", false, "param=value"},
 	}
 
 	for _, v := range testcases {
 		urlx, err := ParseURL(v.inputURL, v.unsafe)
 		require.Nilf(t, err, "got error for url %v", v.inputURL)
 		require.Equal(t, v.expectedParam, urlx.Params.Encode())
+	}
+}
+
+func TestURLFragment(t *testing.T) {
+	testcases := []struct {
+		inputURL         string
+		unsafe           bool
+		expectedFragment string
+	}{
+		{"https://scanme.sh/admin?param=value#highlight", false, "highlight"},
+		{"https://scanme.sh/#highlight", true, "highlight"},
+	}
+
+	for _, v := range testcases {
+		urlx, err := ParseURL(v.inputURL, v.unsafe)
+		require.Nilf(t, err, "got error for url %v", v.inputURL)
+		require.Equalf(t, v.expectedFragment, urlx.Fragment, "got error for url %v", v.inputURL)
 	}
 }

--- a/url/url_test.go
+++ b/url/url_test.go
@@ -117,3 +117,35 @@ func TestParseRelativePath(t *testing.T) {
 		require.Equal(t, v.expectedPath, urlx.GetRelativePath())
 	}
 }
+
+func TestParseFragment(t *testing.T) {
+	testcases := []struct {
+		inputURL         string
+		unsafe           bool
+		expectedFragment string
+	}{
+		{"https://admin?param=value#highlight", false, "highlight"},
+	}
+
+	for _, v := range testcases {
+		urlx, err := ParseURL(v.inputURL, v.unsafe)
+		require.Nilf(t, err, "got error for url %v", v.inputURL)
+		require.Equal(t, v.expectedFragment, urlx.Fragment)
+	}
+}
+
+func TestParseParam(t *testing.T) {
+	testcases := []struct {
+		inputURL      string
+		unsafe        bool
+		expectedParam string
+	}{
+		{"https://admin?param=value#highlight", false, "param=value"},
+	}
+
+	for _, v := range testcases {
+		urlx, err := ParseURL(v.inputURL, v.unsafe)
+		require.Nilf(t, err, "got error for url %v", v.inputURL)
+		require.Equal(t, v.expectedParam, urlx.Params.Encode())
+	}
+}


### PR DESCRIPTION
Closes #247.

Before:
```console
$ cat main.go
package main

import (
	"log"

	urlutil "github.com/projectdiscovery/utils/url"
)

func main() {
	u, err := urlutil.ParseURL("https://admin/aaa#vvvv", false)
	if err != nil {
		log.Fatal(err)
	}
	log.Println(u.Fragment)
}
$ go run .
2023/08/23 22:48:05 
```


After:
```console
$ cat main.go 
package main

import (
        "log"

        urlutil "github.com/projectdiscovery/utils/url"
)

func main() {
        u, err := urlutil.ParseURL("https://admin?param=value#high", false)
        if err != nil {
                log.Fatal(err)
        }
        log.Println(u.Fragment)
        log.Println(u.RawQuery)
}

$ go run .
2023/08/24 10:53:12 high
2023/08/24 10:53:12 param=value
```