### PR TITLE
add HasPrefixAnyI

### DIFF
--- a/strings/stringsutil.go
+++ b/strings/stringsutil.go
@@ -56,6 +56,16 @@ func HasPrefixAny(s string, prefixes ...string) bool {
 	return false
 }
 
+// HasPrefixAnyI is case insensitive HasPrefixAny
+func HasPrefixAnyI(s string, prefixes ...string) bool {
+	for _, prefix := range prefixes {
+		if HasPrefixI(s, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
 // HasSuffixAny checks if the string ends with any specified suffix
 func HasSuffixAny(s string, suffixes ...string) bool {
 	for _, suffix := range suffixes {

--- a/strings/stringsutil_test.go
+++ b/strings/stringsutil_test.go
@@ -79,6 +79,19 @@ func TestHasPrefixAny(t *testing.T) {
 	}
 }
 
+func TestHasPrefixAnyI(t *testing.T) {
+	tests := map[string]prefixsuffixtest{
+		"A b c":     {Prefixes: []string{"a"}, Result: true},
+		"A B c d":   {Prefixes: []string{"a b", "a"}, Result: true},
+		"a b c d e": {Prefixes: []string{"b", "o", "A"}, Result: true},
+		"test test": {Prefixes: []string{"a", "b"}, Result: false},
+	}
+	for str, test := range tests {
+		res := HasPrefixAnyI(str, test.Prefixes...)
+		require.Equalf(t, test.Result, res, "test: %s prefixes: %+v result: %s", str, test.Prefixes, res)
+	}
+}
+
 func TestHasSuffixAny(t *testing.T) {
 	tests := map[string]prefixsuffixtest{
 		"a b c":     {Suffixes: []string{"c"}, Result: true},


### PR DESCRIPTION
### Proposal
The signature should be similar to the following one:
```go
func HasPrefixAnyI(str string, prefixes ...string) { ... }
```
for each `prefix` in `prefixes` we need to check if `stringutil.HasPrefixI(str, prefix)`

Closes #249.