### PR TITLE
fix HasCapNetRaw err

### DIFF
--- a/permission/permission_linux.go
+++ b/permission/permission_linux.go
@@ -27,16 +27,16 @@ func checkCurrentUserCapNetRaw() (bool, error) {
 		Version: unix.LINUX_CAPABILITY_VERSION_3,
 		Pid:     int32(os.Getpid()),
 	}
-	data := unix.CapUserData{}
+	data := [2]unix.CapUserData{}
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
-	err := unix.Capget(&header, &data)
+	err := unix.Capget(&header, &data[0])
 	if err != nil {
 		return false, err
 	}
-	data.Inheritable = (1 << unix.CAP_NET_RAW)
-	if err = unix.Capset(&header, &data); err != nil {
+	data[0].Inheritable = (1 << unix.CAP_NET_RAW)
+	if err = unix.Capset(&header, &data[0]); err != nil {
 		return false, err
 	}
 	return true, nil


### PR DESCRIPTION
Closes https://github.com/projectdiscovery/subfinder/issues/966.

When using LINUX_CAPABILITY_VERSION_3, the kernel expects to communicate capabilities across two CapUserData structures due to the way Linux capabilities are split up:

1. The first CapUserData structure contains capabilities 0 through 31.
2. The second CapUserData structure contains capabilities 32 through 63.

This is because each CapUserData structure can contain a set of capabilities represented as a bitmask of up to 32 capabilities. Linux defines more than 32 capabilities, so two structures are needed.

ref: capabilities(7) and capget(2).

