### PR TITLE
Call parseUnsafeRelativePath() on non-relative paths.

### DIFF
--- a/url/url.go
+++ b/url/url.go
@@ -308,6 +308,10 @@ func ParseURL(inputURL string, unsafe bool) (*URL, error) {
 	}
 	if u.IsRelative {
 		return ParseRelativePath(inputURL, unsafe)
+	} else if unsafe {
+		// we are not relative, but we still need to call this in order to call
+		// the internal parser for paths url.Parse will not handle.
+		u.parseUnsafeRelativePath()
 	}
 	return u, nil
 }

--- a/url/url_test.go
+++ b/url/url_test.go
@@ -137,10 +137,17 @@ func TestParseFragmentRelativePath(t *testing.T) {
 }
 
 func TestParseInvalidUnsafe(t *testing.T) {
-	input := "https://127.0.0.1/%25"
-	u, err := ParseURL(input, true)
-	require.Nilf(t, err, "got error for url %v", input)
-	require.Equal(t, input, u.String())
+	testcases := []string{
+		"https://127.0.0.1/%25",
+		"https://127.0.0.1/%25/aaaa",
+		"https://127.0.0.1/%25/bb/%45?a=1",
+	}
+
+	for _, input := range testcases {
+		u, err := ParseURL(input, true)
+		require.Nilf(t, err, "got error for url %v", input)
+		require.Equal(t, input, u.String())
+	}
 }
 
 func TestParseParam(t *testing.T) {

--- a/url/url_test.go
+++ b/url/url_test.go
@@ -136,6 +136,13 @@ func TestParseFragmentRelativePath(t *testing.T) {
 	}
 }
 
+func TestParseInvalidUnsafe(t *testing.T) {
+	input := "https://127.0.0.1/%25"
+	u, err := ParseURL(input, true)
+	require.Nilf(t, err, "got error for url %v", input)
+	require.Equal(t, input, u.String())
+}
+
 func TestParseParam(t *testing.T) {
 	testcases := []struct {
 		inputURL      string


### PR DESCRIPTION
While attempting to use `httpx`, I found that it was not able to process URLs like `https://127.0.0.1/%25`; this is because the base golang URL parser will discard those chars as invalid.

Fortunately, this library has another mechanism that can be called for these specific cases, but unfortunately this function was not being called for non-relative URLs.

This attempts to fix that issue but calls `parseUnsafeRelativePath` when non-relative and only when the unsafe boolean is passed to ParseURL.

Let me know if there are any issues.