### PR TITLE
add marshal/unmarshal for orderedmap without changing order

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -56,6 +56,7 @@ require (
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.19 // indirect
 	github.com/mattn/go-runewidth v0.0.14 // indirect
+	github.com/metalim/jsonmap v0.4.1 // indirect
 	github.com/mholt/archiver/v3 v3.5.1 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -133,6 +133,8 @@ github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m
 github.com/mattn/go-runewidth v0.0.12/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
 github.com/mattn/go-runewidth v0.0.14 h1:+xnbZSEeDbOIg5/mE6JF0w6n9duR1l3/WmbinWVwUuU=
 github.com/mattn/go-runewidth v0.0.14/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
+github.com/metalim/jsonmap v0.4.1 h1:kvj9Q5oj+xne2APsoe34LmJGTUlrY3D9WYw2zwbVuVM=
+github.com/metalim/jsonmap v0.4.1/go.mod h1:Rlps8z72TXjyqKPAE7pttAsBfhiZ99FLn0qzxvT4jDs=
 github.com/mholt/archiver/v3 v3.5.1 h1:rDjOBX9JSF5BvoJGvjqK479aL70qh9DIpZCl+k7Clwo=
 github.com/mholt/archiver/v3 v3.5.1/go.mod h1:e3dqJ7H78uzsRSEACH1joayhuSyhnonssnDhppzS1L4=
 github.com/microcosm-cc/bluemonday v1.0.21/go.mod h1:ytNkv4RrDrLJ2pqlsSI46O6IVXmZOBBD4SaJyDwwTkM=

--- a/maps/ordered_map_test.go
+++ b/maps/ordered_map_test.go
@@ -1,7 +1,9 @@
 package mapsutil
 
 import (
+	"encoding/json"
 	"fmt"
+	"reflect"
 	"strconv"
 	"testing"
 )
@@ -69,4 +71,73 @@ func TestOrderedMap(t *testing.T) {
 		}
 	}
 
+}
+
+func TestOrderedMapMarshalUnmarshal(t *testing.T) {
+	t.Run("TestSimpleStringToStringMapping", func(t *testing.T) {
+		orderedMap1 := NewOrderedMap[string, string]()
+		orderedMap1.Set("name", "John Doe")
+		orderedMap1.Set("occupation", "Software Developer")
+
+		marshaled1, err := json.Marshal(orderedMap1)
+		if err != nil {
+			t.Fatalf("Failed to marshal orderedMap1: %v", err)
+		}
+
+		unmarshaled1 := NewOrderedMap[string, string]()
+		err = json.Unmarshal(marshaled1, &unmarshaled1)
+		if err != nil {
+			t.Fatalf("Failed to unmarshal orderedMap1: %v", err)
+		}
+
+		if !reflect.DeepEqual(orderedMap1, unmarshaled1) {
+			t.Fatal("Unmarshaled map is not equal to the original map for orderedMap1")
+		}
+	})
+
+	t.Run("TestIntegerToStructMapping", func(t *testing.T) {
+		type Employee struct {
+			ID   int    `json:"id"`
+			Name string `json:"name"`
+		}
+		orderedMap2 := NewOrderedMap[int, Employee]()
+		orderedMap2.Set(1, Employee{ID: 1, Name: "Alice"})
+		orderedMap2.Set(2, Employee{ID: 2, Name: "Bob"})
+
+		marshaled2, err := json.Marshal(orderedMap2)
+		if err != nil {
+			t.Fatalf("Failed to marshal orderedMap2: %v", err)
+		}
+
+		unmarshaled2 := NewOrderedMap[int, Employee]()
+		err = json.Unmarshal(marshaled2, &unmarshaled2)
+		if err != nil {
+			t.Fatalf("Failed to unmarshal orderedMap2: %v", err)
+		}
+
+		if !reflect.DeepEqual(orderedMap2, unmarshaled2) {
+			t.Fatal("Unmarshaled map is not equal to the original map for orderedMap2")
+		}
+	})
+
+	t.Run("TestStringToSliceOfStringsMapping", func(t *testing.T) {
+		orderedMap3 := NewOrderedMap[string, []string]()
+		orderedMap3.Set("fruits", []string{"apple", "banana", "cherry"})
+		orderedMap3.Set("vegetables", []string{"tomato", "potato", "carrot"})
+
+		marshaled3, err := json.Marshal(orderedMap3)
+		if err != nil {
+			t.Fatalf("Failed to marshal orderedMap3: %v", err)
+		}
+
+		unmarshaled3 := NewOrderedMap[string, []string]()
+		err = json.Unmarshal(marshaled3, &unmarshaled3)
+		if err != nil {
+			t.Fatalf("Failed to unmarshal orderedMap3: %v", err)
+		}
+
+		if !reflect.DeepEqual(orderedMap3, unmarshaled3) {
+			t.Fatal("Unmarshaled map is not equal to the original map for orderedMap3")
+		}
+	})
 }


### PR DESCRIPTION
### Proposed Changes

- we use orderedmap in nuclei to make sure order of headers/params do not change
- this pr implements custom json marshal / unmarshal interface to OrderedMap[k comparable,v any] type such that underlying output json remains the same 
- used in https://github.com/projectdiscovery/nuclei/pull/4477