### PR TITLE
OrderedMap: Fix skipping elements while iterating with deletion

### DIFF
--- a/maps/ordered_map.go
+++ b/maps/ordered_map.go
@@ -21,8 +21,9 @@ var (
 // Note: Order is only guaranteed for current level of OrderedMap
 // nested values only have order preserved if they are also OrderedMap
 type OrderedMap[k comparable, v any] struct {
-	keys []k
-	m    map[k]v
+	keys    []k
+	m       map[k]v
+	deleted map[int]bool
 }
 
 // Set sets a value in the OrderedMap (if the key already exists, it will be overwritten)
@@ -91,6 +92,36 @@ func (o *OrderedMap[k, v]) Delete(key k) {
 			break
 		}
 	}
+}
+
+// MarkDelete marks a key for deletion
+func (o *OrderedMap[k, v]) MarkDelete(key k) {
+	if o.deleted == nil {
+		o.deleted = map[int]bool{}
+	}
+	for i, k := range o.keys {
+		if k == key {
+			o.deleted[i] = true
+			break
+		}
+	}
+}
+
+// PruneDeleted prunes the deleted keys
+func (o *OrderedMap[k, v]) PruneDeleted() {
+	if o.deleted == nil {
+		return
+	}
+	var keys []k
+	for i, k := range o.keys {
+		if o.deleted[i] {
+			delete(o.m, k)
+		} else {
+			keys = append(keys, k)
+		}
+	}
+	o.keys = keys
+	o.deleted = nil
 }
 
 // Len returns the length of the OrderedMap

--- a/maps/ordered_map.go
+++ b/maps/ordered_map.go
@@ -47,6 +47,9 @@ func (o *OrderedMap[k, v]) Get(key k) (v, bool) {
 // Iterate iterates over the OrderedMap in insertion order
 func (o *OrderedMap[k, v]) Iterate(f func(key k, value v) bool) {
 	o.inIter = true
+	defer func() {
+		o.inIter = false
+	}()
 	for _, key := range o.keys {
 		// silently discard any missing keys from the map
 		if _, ok := o.m[key]; !ok {
@@ -65,7 +68,6 @@ func (o *OrderedMap[k, v]) Iterate(f func(key k, value v) bool) {
 		}
 		o.keys = tmp
 		o.dirty = false
-		o.inIter = false
 	}
 }
 

--- a/maps/ordered_map_test.go
+++ b/maps/ordered_map_test.go
@@ -6,6 +6,8 @@ import (
 	"reflect"
 	"strconv"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestOrderedMapBasic(t *testing.T) {
@@ -140,4 +142,25 @@ func TestOrderedMapMarshalUnmarshal(t *testing.T) {
 			t.Fatal("Unmarshaled map is not equal to the original map for orderedMap3")
 		}
 	})
+}
+
+func TestOrderedMapDeleteWhileIterating(t *testing.T) {
+	om := NewOrderedMap[string, string]()
+	om.Set("key1", "value1")
+	om.Set("key2", "value2")
+	om.Set("key3", "value3")
+
+	ignoreKey := "key1"
+
+	got := []string{}
+
+	om.Iterate(func(key string, value string) bool {
+		got = append(got, key)
+		if key == ignoreKey {
+			om.Delete(key)
+		}
+		return true
+	})
+
+	require.ElementsMatchf(t, []string{"key1", "key2", "key3"}, got, "inconsistent iteration order")
 }

--- a/url/orderedparams.go
+++ b/url/orderedparams.go
@@ -85,6 +85,16 @@ func (o *OrderedParams) Del(key string) {
 	o.om.Delete(key)
 }
 
+// MarkDelete marks the key as deleted
+func (o *OrderedParams) MarkDelete(key string) {
+	o.om.MarkDelete(key)
+}
+
+// PruneDeleted prunes the deleted keys
+func (o *OrderedParams) PruneDeleted() {
+	o.om.PruneDeleted()
+}
+
 // Merges given paramset into existing one with base as priority
 func (o *OrderedParams) Merge(raw string) {
 	o.Decode(raw)

--- a/url/orderedparams.go
+++ b/url/orderedparams.go
@@ -85,16 +85,6 @@ func (o *OrderedParams) Del(key string) {
 	o.om.Delete(key)
 }
 
-// MarkDelete marks the key as deleted
-func (o *OrderedParams) MarkDelete(key string) {
-	o.om.MarkDelete(key)
-}
-
-// PruneDeleted prunes the deleted keys
-func (o *OrderedParams) PruneDeleted() {
-	o.om.PruneDeleted()
-}
-
 // Merges given paramset into existing one with base as priority
 func (o *OrderedParams) Merge(raw string) {
 	o.Decode(raw)


### PR DESCRIPTION
- closes: #351 

__Code can be updated with this snippest:__
```go
func main() {
	om := mapsutil.NewOrderedMap[string, string]()
	om.Set("offset", "0")
	om.Set("limit", "10")
	om.Set("sort", "desc")
	om.Set("cwe-id", "CWE-77")

	ignoreKeys := []string{"offset", "limit", "sort"}

	om.Iterate(func(key string, value string) bool {
		fmt.Println(key, value)
		for _, ignoreKey := range ignoreKeys {
			if key == ignoreKey {
				om.MarkDelete(key)
				break
			}
		}
		return true
	})
	om.PruneDeleted()
}
```