### PR TITLE
executil: add missing cause error

### DIFF
--- a/exec/executil.go
+++ b/exec/executil.go
@@ -144,9 +144,19 @@ func RunSafe(cmd ...string) (string, error) {
 
 	cmdExec := exec.Command(execpath, cmdArgs...)
 
-	in, _ := cmdExec.StdinPipe()
-	errorOut, _ := cmdExec.StderrPipe()
-	out, _ := cmdExec.StdoutPipe()
+	in, err := cmdExec.StdinPipe()
+	if err != nil {
+		return "", errkit.WithMessage(err, "failed to create stdin pipe")
+	}
+	errorOut, err := cmdExec.StderrPipe()
+	if err != nil {
+		return "", errkit.WithMessage(err, "failed to create stderr pipe")
+	}
+	out, err := cmdExec.StdoutPipe()
+	if err != nil {
+		return "", errkit.WithMessage(err, "failed to create stdout pipe")
+	}
+
 	defer in.Close()
 	defer errorOut.Close()
 	defer out.Close()
@@ -175,9 +185,20 @@ func RunSafe(cmd ...string) (string, error) {
 // RunSh the specified command through sh
 func RunSh(cmd ...string) (string, error) {
 	cmdExec := exec.Command("sh", "-c", strings.Join(cmd, " "))
-	in, _ := cmdExec.StdinPipe()
-	errorOut, _ := cmdExec.StderrPipe()
-	out, _ := cmdExec.StdoutPipe()
+
+	in, err := cmdExec.StdinPipe()
+	if err != nil {
+		return "", errkit.WithMessage(err, "failed to create stdin pipe")
+	}
+	errorOut, err := cmdExec.StderrPipe()
+	if err != nil {
+		return "", errkit.WithMessage(err, "failed to create stderr pipe")
+	}
+	out, err := cmdExec.StdoutPipe()
+	if err != nil {
+		return "", errkit.WithMessage(err, "failed to create stdout pipe")
+	}
+
 	defer in.Close()
 	defer errorOut.Close()
 	defer out.Close()
@@ -223,9 +244,19 @@ func RunPS(cmd string) (string, error) {
 
 	cmdExec := exec.Command("powershell.exe", "-EncodedCommand", b64cmd)
 
-	in, _ := cmdExec.StdinPipe()
-	errorOut, _ := cmdExec.StderrPipe()
-	out, _ := cmdExec.StdoutPipe()
+	in, err := cmdExec.StdinPipe()
+	if err != nil {
+		return "", errkit.WithMessage(err, "failed to create stdin pipe")
+	}
+	errorOut, err := cmdExec.StderrPipe()
+	if err != nil {
+		return "", errkit.WithMessage(err, "failed to create stderr pipe")
+	}
+	out, err := cmdExec.StdoutPipe()
+	if err != nil {
+		return "", errkit.WithMessage(err, "failed to create stdout pipe")
+	}
+
 	defer in.Close()
 	defer errorOut.Close()
 	defer out.Close()

--- a/exec/executil.go
+++ b/exec/executil.go
@@ -126,8 +126,7 @@ func RunSafe(cmd ...string) (string, error) {
 	execpath, err := exec.LookPath(cmd[0])
 	if err != nil {
 		if runtime.GOOS == "windows" {
-			patherror := errkit.New("RunSafe does not allow relative exection of binaries (ex ./main) due to security reasons")
-			return "", errkit.Append(patherror, err)
+			return "", errkit.WithMessage(err, "RunSafe does not allow relative exection of binaries (ex ./main) due to security reasons")
 		}
 		return "", err
 	}
@@ -232,7 +231,7 @@ func RunPS(cmd string) (string, error) {
 	defer out.Close()
 
 	if err := cmdExec.Start(); err != nil {
-		return "", errkit.New("start powershell.exe process error")
+		return "", errkit.WithMessage(err, "start powershell.exe process error")
 	}
 
 	outData, _ := io.ReadAll(out)


### PR DESCRIPTION
## Proposed Changes

- `executil` was not returning original error (aka cause) in case of exec.ExitError which is now resolved