### PR TITLE
errkit: detect permanent network errors when behind http/socks proxy

### DIFF
--- a/errkit/kind.go
+++ b/errkit/kind.go
@@ -126,6 +126,12 @@ func isNetworkPermanentErr(err *ErrorX) bool {
 		return true
 	case strings.Contains(v, "connect: connection refused"):
 		return true
+	case strings.Contains(v, "Unable to connect"):
+		// occurs when HTTP(S) proxy is used
+		return true
+	case strings.Contains(v, "host unreachable"):
+		// occurs when SOCKS proxy is used
+		return true
 	}
 	return false
 }


### PR DESCRIPTION
If HTTP(S)/SOCKS proxies are used the errors returned by http.Client are different.

For HTTP proxy:

```go
dialer := http.ProxyURL(uri)
http.DefaultTransport.(*http.Transport).Proxy = dialer
_, err= http.DefaultClient.Get("https://this.does.not.exist")
fmt.Println(err)
```

<img width="446" alt="image" src="https://github.com/projectdiscovery/utils/assets/91873652/35cdc824-858f-40d6-9e77-4f8702954d7b">

compared to no proxy:

<img width="742" alt="image" src="https://github.com/projectdiscovery/utils/assets/91873652/c458ba2d-9c5c-425e-aeff-a5f93317ba8e">
