### PR TITLE
Replace filepath.Walk with filepath.WalkDir 

### DIFF
--- a/folder/folderutil.go
+++ b/folder/folderutil.go
@@ -1,6 +1,7 @@
 package folderutil
 
 import (
+	"io/fs"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -30,11 +31,11 @@ const (
 // GetFiles within a folder
 func GetFiles(root string) ([]string, error) {
 	var matches []string
-	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
-		if info.IsDir() {
+		if d.IsDir() {
 			return nil
 		}
 		matches = append(matches, path)
@@ -241,11 +242,11 @@ func SyncDirectory(source, destination string) error {
 // DedupeLinesInFiles deduplicates lines in all files in a directory
 // The function can be memory intensive for directories with large files.
 func DedupeLinesInFiles(dir string) error {
-	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
-		if !info.IsDir() {
+		if !d.IsDir() {
 			return fileutil.DedupeLines(path)
 		}
 		return nil

--- a/memoize/gen/generic/memoize.go
+++ b/memoize/gen/generic/memoize.go
@@ -22,14 +22,14 @@ var (
 func main() {
 	flag.Parse()
 
-	err := filepath.Walk(*src, walk)
+	err := filepath.WalkDir(*src, walkDir)
 	if err != nil {
 		log.Fatal(err)
 	}
 }
 
-func walk(path string, info fs.FileInfo, err error) error {
-	if info.IsDir() {
+func walkDir(path string, d fs.DirEntry, err error) error {
+	if d.IsDir() {
 		return nil
 	}
 


### PR DESCRIPTION
filepath.WalkDir avoids unnecessary sys calls since it provides a fs.DirEntry, which includes file type information without requiring a stat call.