### PR TITLE
Fix version semver comparison when equal #6150

### DIFF
--- a/update/types.go
+++ b/update/types.go
@@ -82,7 +82,7 @@ func IsOutdated(current, latest string) bool {
 		// fallback to naive comparison
 		return current != latest
 	}
-	return latestVer.GreaterThan(currentVer)
+	return currentVer.LessThan(latestVer)
 }
 
 // IsDevReleaseOutdated returns true if installed tool (dev version) is outdated

--- a/update/types_test.go
+++ b/update/types_test.go
@@ -1,6 +1,7 @@
 package updateutils
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -8,55 +9,46 @@ import (
 
 func TestIsOutdated(t *testing.T) {
 	tests := []struct {
-		name     string
 		current  string
 		latest   string
 		expected bool
 	}{
 		{
-			name:     "Current version is older than latest",
 			current:  "1.0.0",
 			latest:   "1.1.0",
 			expected: true,
 		},
 		{
-			name:     "Current version is same as latest",
 			current:  "1.0.0",
 			latest:   "1.0.0",
 			expected: false,
 		},
 		{
-			name:     "Current version is newer than latest",
 			current:  "1.1.0",
 			latest:   "1.0.0",
 			expected: false,
 		},
 		{
-			name:     "Current version is dev version",
 			current:  "1.0.0-dev",
 			latest:   "1.0.0",
 			expected: true,
 		},
 		{
-			name:     "Invalid version format - fallback to string comparison",
 			current:  "invalid",
 			latest:   "1.0.0",
 			expected: true,
 		},
 		{
-			name:     "Both versions invalid - fallback to string comparison",
 			current:  "invalid1",
 			latest:   "invalid2",
 			expected: true,
 		},
 		{
-			name:     "Pre-release version comparison",
 			current:  "1.0.0-alpha",
 			latest:   "1.0.0",
 			expected: true,
 		},
 		{
-			name:     "Pre-release version comparison with same base version",
 			current:  "1.0.0-alpha",
 			latest:   "1.0.0-beta",
 			expected: true,
@@ -64,7 +56,7 @@ func TestIsOutdated(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(fmt.Sprintf("current: %v, latest: %v", tt.current, tt.latest), func(t *testing.T) {
 			assert.Equal(t, tt.expected, IsOutdated(tt.current, tt.latest), "version comparison failed")
 		})
 	}

--- a/update/types_test.go
+++ b/update/types_test.go
@@ -1,0 +1,71 @@
+package updateutils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsOutdated(t *testing.T) {
+	tests := []struct {
+		name     string
+		current  string
+		latest   string
+		expected bool
+	}{
+		{
+			name:     "Current version is older than latest",
+			current:  "1.0.0",
+			latest:   "1.1.0",
+			expected: true,
+		},
+		{
+			name:     "Current version is same as latest",
+			current:  "1.0.0",
+			latest:   "1.0.0",
+			expected: false,
+		},
+		{
+			name:     "Current version is newer than latest",
+			current:  "1.1.0",
+			latest:   "1.0.0",
+			expected: false,
+		},
+		{
+			name:     "Current version is dev version",
+			current:  "1.0.0-dev",
+			latest:   "1.0.0",
+			expected: true,
+		},
+		{
+			name:     "Invalid version format - fallback to string comparison",
+			current:  "invalid",
+			latest:   "1.0.0",
+			expected: true,
+		},
+		{
+			name:     "Both versions invalid - fallback to string comparison",
+			current:  "invalid1",
+			latest:   "invalid2",
+			expected: true,
+		},
+		{
+			name:     "Pre-release version comparison",
+			current:  "1.0.0-alpha",
+			latest:   "1.0.0",
+			expected: true,
+		},
+		{
+			name:     "Pre-release version comparison with same base version",
+			current:  "1.0.0-alpha",
+			latest:   "1.0.0-beta",
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, IsOutdated(tt.current, tt.latest), "version comparison failed")
+		})
+	}
+}


### PR DESCRIPTION
Issue: https://github.com/projectdiscovery/nuclei/issues/6150

Currently, the IsOutdated method under the utils package was checking if the current version of the tool was greater than the latest version. This fails when the version are equal. 

Changes made: 
- Use LessThan for comparison
- Added some tests for this too. 

Testing Done:

Before, the version used to say outdated.

```
[INF] nuclei-templates are not installed, installing...
[INF] Successfully installed nuclei-templates at /Users/sudhanvahebbale/nuclei-templates
[INF] Current nuclei version: **v3.4.2 (outdated)**
[INF] Current nuclei-templates version:  (latest)
[WRN] Scan results upload to cloud is disabled.
...
...
```

After the fix: 
```
[INF] nuclei-templates are not installed, installing...
[INF] Successfully installed nuclei-templates at /Users/sudhanvahebbale/nuclei-templates
[INF] Current nuclei version: **v3.4.2 (latest)**
[INF] Current nuclei-templates version: v10.1.7 (latest)
[WRN] Scan results upload to cloud is disabled.
...
...
```