### PR TITLE
build: Add missing build tag for dragonfly

### DIFF
--- a/permission/permission_other.go
+++ b/permission/permission_other.go
@@ -1,4 +1,4 @@
-//go:build darwin || freebsd || netbsd || openbsd || solaris || android || ios || (linux && armv7l) || (linux && armv8l)
+//go:build darwin || freebsd || netbsd || dragonfly || openbsd || solaris || android || ios || (linux && armv7l) || (linux && armv8l)
 
 package permissionutil
 


### PR DESCRIPTION
This is a tiny PR to enable building nuclei packages for [DragonFly BSD](https://www.dragonflybsd.org/).