### PR TITLE
refactor(errorutil): impl proper err wrapping w/ stdlib compat

### DIFF
--- a/errors/err_test.go
+++ b/errors/err_test.go
@@ -1,38 +1,46 @@
 package errorutil_test
 
 import (
-	"fmt"
+	"errors"
 	"strings"
 	"testing"
 
-	errors "github.com/projectdiscovery/utils/errors"
+	errorutil "github.com/projectdiscovery/utils/errors"
 )
 
+type customError struct {
+	msg string
+}
+
+func (c *customError) Error() string {
+	return c.msg
+}
+
 func TestErrorEqual(t *testing.T) {
-	err1 := fmt.Errorf("error init x")
-	err2 := errors.NewWithErr(err1)
-	err3 := errors.NewWithTag("testing", "error init")
+	err1 := errors.New("error init x")
+	err2 := errorutil.NewWithErr(err1)
+	err3 := errorutil.NewWithTag("testing", "error init")
 	var errnil error
 
-	if !errors.IsAny(err1, err2, errnil) {
+	if !errorutil.IsAny(err1, err2, errnil) {
 		t.Errorf("expected errors to be equal")
 	}
-	if errors.IsAny(err1, err3, errnil) {
+	if errorutil.IsAny(err1, err3, errnil) {
 		t.Errorf("expected error to be not equal")
 	}
 }
 
 func TestWrapWithNil(t *testing.T) {
-	err1 := errors.NewWithTag("niltest", "non nil error").WithLevel(errors.Fatal)
+	err1 := errorutil.NewWithTag("niltest", "non nil error").WithLevel(errorutil.Fatal)
 	var errx error
 
-	if errors.WrapwithNil(errx, err1) != nil {
+	if errorutil.WrapwithNil(errx, err1) != nil {
 		t.Errorf("when base error is nil ")
 	}
 }
 
 func TestStackTrace(t *testing.T) {
-	err := errors.New("base error")
+	err := errorutil.New("base error")
 	relay := func(err error) error {
 		return err
 	}
@@ -42,7 +50,7 @@ func TestStackTrace(t *testing.T) {
 		if strings.Contains(errx.Error(), "captureStack") {
 			t.Errorf("stacktrace should be disabled by default")
 		}
-		errors.ShowStackTrace = true
+		errorutil.ShowStackTrace = true
 		if !strings.Contains(errx.Error(), "captureStack") {
 			t.Errorf("missing stacktrace got %v", errx.Error())
 		}
@@ -52,8 +60,8 @@ func TestStackTrace(t *testing.T) {
 func TestErrorCallback(t *testing.T) {
 	callbackExecuted := false
 
-	err := errors.NewWithTag("callback", "got error").WithCallback(func(level errors.ErrorLevel, err string, tags ...string) {
-		if level != errors.Runtime {
+	err := errorutil.NewWithTag("callback", "got error").WithCallback(func(level errorutil.ErrorLevel, err string, tags ...string) {
+		if level != errorutil.Runtime {
 			t.Errorf("Default error level should be Runtime")
 		}
 		if tags[0] != "callback" {
@@ -70,5 +78,64 @@ func TestErrorCallback(t *testing.T) {
 
 	if !callbackExecuted {
 		t.Errorf("error callback failed to execute")
+	}
+}
+
+func TestErrorIs(t *testing.T) {
+	var ErrTest = errors.New("test error")
+
+	err := errorutil.NewWithErr(ErrTest).Msgf("message %s", "test")
+
+	if !errors.Is(err, ErrTest) {
+		t.Errorf("expected error to match ErrTest")
+	}
+}
+
+func TestUnwrap(t *testing.T) {
+	// Test basic unwrapping
+	baseErr := errors.New("base error")
+	wrappedErr := errorutil.NewWithErr(baseErr)
+
+	if !errors.Is(wrappedErr, baseErr) {
+		t.Errorf("expected wrapped error to match base error")
+	}
+
+	// Test unwrapping thru error chain
+	middleErr := errorutil.NewWithErr(baseErr).WithTag("middle")
+	topErr := errorutil.NewWithErr(middleErr).WithTag("top")
+
+	if !errors.Is(topErr, baseErr) {
+		t.Errorf("expected topErr to match baseErr through chain")
+	}
+
+	if !errors.Is(topErr, middleErr) {
+		t.Errorf("expected topErr to match middleErr")
+	}
+
+	// Test direct unwrap method
+	if unwrapped := errors.Unwrap(wrappedErr); unwrapped != baseErr {
+		t.Errorf("expected direct unwrap to return baseErr, got %v", unwrapped)
+	}
+
+	// Test unwrapping with Wrap method
+	err1 := errors.New("first error")
+	err2 := errors.New("second error")
+	combined := errorutil.New("combined error").Wrap(err1, err2)
+
+	if !errors.Is(combined, err1) {
+		t.Errorf("expected combined error to match err1")
+	}
+
+	// Test errors.As functionality
+	customErr := &customError{msg: "custom error"}
+	wrappedCustom := errorutil.NewWithErr(customErr).WithTag("wrapped")
+
+	var targetCustom *customError
+	if !errors.As(wrappedCustom, &targetCustom) {
+		t.Errorf("expected errors.As to find custom error type")
+	}
+
+	if targetCustom.msg != "custom error" {
+		t.Errorf("expected custom error message 'custom error', got %s", targetCustom.msg)
 	}
 }

--- a/errors/errinterface.go
+++ b/errors/errinterface.go
@@ -9,6 +9,8 @@ type Error interface {
 	WithLevel(level ErrorLevel) Error
 	// Error is interface method of 'error'
 	Error() string
+	// Unwrap returns the underlying error
+	Unwrap() error
 	// Wraps existing error with errors (skips if passed error is nil)
 	Wrap(err ...error) Error
 	// Msgf wraps error with given message


### PR DESCRIPTION
Follow up on projectdiscovery/nuclei#6326

changes:

* add `wrappedErr` field to `enrichedError` to maintain error chains.
* implement `Unwrap()` method to supports builtin `errors.Is`/`errors.As`.
* refactor `Wrap()` method to preserve err chains instead of str concat.
* update `NewWithErr()` to properly wrap errors while preserving tags & stacktrace.
* enhance `Equal()` method to check wrapped error chains using `errors.Is`.
* improve `IsAny()` func to use bidirectional `errors.Is` checking.

so basically these changes enable runtime type assertion via builtin `errors.Is`/`errors.As` func for granular error handling in call stacks while maintaining backward compatibility w/ existing enriched error feats.