### PR TITLE
path encoding / decoding helpers

### DIFF
--- a/url/encoding.go
+++ b/url/encoding.go
@@ -1,10 +1,1 @@
 package urlutil
-
-import (
-	"github.com/projectdiscovery/utils/env"
-)
-
-// SpaceEncoding determines how spaces are encoded in URLs via external environment variable:
-// - When empty (""), spaces are encoded as "+"
-// - When set to "percent", spaces are encoded as "%20"
-var SpaceEncoding = env.GetEnvOrDefault("SPACE_ENCODING", "")


### PR DESCRIPTION
## Proposed Changes

- we until now interchangeably used RawParams for url encoding and decoding , but there are some minor differences between `path` encoding/decoding vs `queryparam` encoding/decoding
- this pr differenciates that by adding different helper functions for that 
- more context and information etc will be shared in the associated nuclei update-utils pull request