### PR TITLE
feat(structs): add `FilterStructToMap` utility function

### DIFF
--- a/structs/structs_test.go
+++ b/structs/structs_test.go
@@ -16,6 +16,15 @@ type NestedStruct struct {
 	PtrField *TestStruct
 }
 
+type MapTestStruct struct {
+	Name     string `json:"name"`
+	Age      int    `json:"age,omitempty"`
+	Password string `json:"-"`
+	IsActive bool   `json:"is_active"`
+	Address  string `json:"address"`
+	Country  string `json:"country,omitempty"`
+}
+
 func TestFilterStruct(t *testing.T) {
 	s := TestStruct{
 		Name:    "John",
@@ -25,7 +34,7 @@ func TestFilterStruct(t *testing.T) {
 
 	tests := []struct {
 		name          string
-		input         interface{}
+		input         any
 		includeFields []string
 		excludeFields []string
 		want          TestStruct
@@ -79,6 +88,94 @@ func TestFilterStruct(t *testing.T) {
 	}
 }
 
+func TestFilterStructToMap(t *testing.T) {
+	s := MapTestStruct{
+		Name:     "John",
+		Age:      30,                // To test omitempty on a non zero value
+		Password: "secret-password", // To test an ignored tag (json:"-")
+		IsActive: true,
+		Address:  "New York",
+		Country:  "", // To test omitempty on a zero value
+	}
+
+	tests := []struct {
+		name          string
+		input         any
+		includeFields []string
+		excludeFields []string
+		want          map[string]any
+		wantErr       bool
+	}{
+		{
+			name:          "no filtering",
+			input:         s,
+			includeFields: nil,
+			excludeFields: nil,
+			want: map[string]any{
+				"name":      "John",
+				"age":       30,
+				"is_active": true,
+				"address":   "New York",
+			},
+			wantErr: false,
+		},
+		{
+			name:          "include specific fields",
+			input:         s,
+			includeFields: []string{"Name", "Address"},
+			excludeFields: []string{},
+			want: map[string]any{
+				"name":    "John",
+				"address": "New York",
+			},
+			wantErr: false,
+		},
+		{
+			name:          "exclude specific fields",
+			input:         s,
+			includeFields: []string{},
+			excludeFields: []string{"Address", "IsActive"},
+			want: map[string]any{
+				"name": "John",
+				"age":  30,
+			},
+			wantErr: false,
+		},
+		{
+			name:          "include and exclude",
+			input:         s,
+			includeFields: []string{"Name", "Age", "Address"},
+			excludeFields: []string{"Age"},
+			want: map[string]any{
+				"name":    "John",
+				"address": "New York",
+			},
+			wantErr: false,
+		},
+		{
+			name:          "non-struct input",
+			input:         "not a struct",
+			includeFields: []string{},
+			excludeFields: []string{},
+			want:          nil,
+			wantErr:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := FilterStructToMap(tt.input, tt.includeFields, tt.excludeFields)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("FilterStructToMap() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("FilterStructToMap() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestGetStructFields(t *testing.T) {
 	s := TestStruct{
 		Name:    "John",
@@ -88,7 +185,7 @@ func TestGetStructFields(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		input   interface{}
+		input   any
 		want    []string
 		wantErr bool
 	}{


### PR DESCRIPTION
Resolves #673

#### Summary

This PR introduces `FilterStructToMap`, a utility function in the `structs` package that converts a struct into a `map[string]any` while respecting `json` tags, `omitempty`, and user-defined field filters.

This is a direct solution to the problem identified in [naabu#1545](https://github.com/projectdiscovery/naabu/issues/1545), where the existing `FilterStruct` utility caused issues with JSON marshaling due to its zero-value filtering approach.

#### Implementation Details

-   **`FilterStructToMap[T any](...) (map[string]any, error)`:**
    -   Takes a struct and `include/exclude` field lists as input.
    -   Iterates through struct fields using `reflect`.
    -   Uses the `json` tag as the key for the output map.
    -   Skips zero-valued fields when `omitempty` is present.
    -   Respects the `include/exclude` lists for filtering.
    -   Returns a clean map for JSON marshaling.

-   **`walkFilteredFields` (Internal Helper):**
    -   To avoid code duplication, a new internal helper function, `walkFilteredFields`, has been created.
    -   This function encapsulates the common logic of iterating through fields while checking against the `include/exclude` maps.
    -   Refactored `FilterStruct` to reuse the same logic, reducing duplication.

This utility offers a reliable, reusable solution for JSON-safe struct filtering and serialization.
