### PR TITLE
fix: use correct env var names in memguardian init

### DIFF
--- a/memguardian/memguardian.go
+++ b/memguardian/memguardian.go
@@ -25,9 +25,9 @@ const (
 )
 
 func init() {
-	DefaultInterval = env.GetEnvOrDefault(MemGuardianMaxUsedRamRatioENV, time.Duration(time.Second*30))
+	DefaultInterval = env.GetEnvOrDefault(MemGuardianIntervalENV, time.Duration(time.Second*30))
 	DefaultMaxUsedRamRatio = env.GetEnvOrDefault(MemGuardianMaxUsedRamRatioENV, float64(75))
-	maxRam := env.GetEnvOrDefault(MemGuardianMaxUsedRamRatioENV, "")
+	maxRam := env.GetEnvOrDefault(MemGuardianMaxUsedMemoryENV, "")
 
 	options := []MemGuardianOption{
 		WitInterval(DefaultInterval),


### PR DESCRIPTION
Fixed incorrect env var names used in memguardian init() function.

**Bug:** The init() function was using the wrong env var names:
-  was reading  instead of 
-  was reading  instead of 

**Fix:** Changed both to use their respective, correctly-named env vars.

**Before:**
```go
DefaultInterval = env.GetEnvOrDefault(MemGuardianMaxUsedRamRatioENV, time.Duration(time.Second*30))
maxRam := env.GetEnvOrDefault(MemGuardianMaxUsedRamRatioENV, )
```

**After:**
```go
DefaultInterval = env.GetEnvOrDefault(MemGuardianIntervalENV, time.Duration(time.Second*30))
maxRam := env.GetEnvOrDefault(MemGuardianMaxUsedMemoryENV, )
```

This ensures that the documented env vars ( and ) actually work as intended.