### PR TITLE
Move DNSToMap into its own package

### DIFF
--- a/maps/dnsmap/dnsmap.go
+++ b/maps/dnsmap/dnsmap.go
@@ -1,0 +1,53 @@
+// Package dnsmap converts DNS messages into matcher maps.
+//
+// It lives in its own package (rather than in mapsutil) so that the heavy
+// github.com/miekg/dns dependency is only linked into binaries that actually
+// convert DNS messages, instead of every consumer of the generic map helpers.
+package dnsmap
+
+import (
+	"fmt"
+
+	"github.com/miekg/dns"
+)
+
+const defaultFormat = "%s"
+
+// DNSToMap converts a DNS message to a matcher map.
+func DNSToMap(msg *dns.Msg, format string) (m map[string]interface{}) {
+	m = make(map[string]interface{})
+
+	if format == "" {
+		format = defaultFormat
+	}
+
+	m[fmt.Sprintf(format, "rcode")] = msg.Rcode
+
+	var qs string
+	for _, question := range msg.Question {
+		qs += fmt.Sprintln(question.String())
+	}
+	m[fmt.Sprintf(format, "question")] = qs
+
+	var exs string
+	for _, extra := range msg.Extra {
+		exs += fmt.Sprintln(extra.String())
+	}
+	m[fmt.Sprintf(format, "extra")] = exs
+
+	var ans string
+	for _, answer := range msg.Answer {
+		ans += fmt.Sprintln(answer.String())
+	}
+	m[fmt.Sprintf(format, "answer")] = ans
+
+	var nss string
+	for _, ns := range msg.Ns {
+		nss += fmt.Sprintln(ns.String())
+	}
+	m[fmt.Sprintf(format, "ns")] = nss
+
+	m[fmt.Sprintf(format, "raw")] = msg.String()
+
+	return m
+}

--- a/maps/dnsmap/dnsmap_test.go
+++ b/maps/dnsmap/dnsmap_test.go
@@ -1,0 +1,21 @@
+package dnsmap
+
+import (
+	"net"
+	"testing"
+
+	"github.com/miekg/dns"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDNSToMap(t *testing.T) {
+	msg := dns.Msg{}
+	msg.Rcode = 1
+	msg.Question = []dns.Question{{Name: "test", Qtype: 1, Qclass: 1}}
+	msg.Extra = []dns.RR{&dns.A{Hdr: dns.RR_Header{Name: "test", Rrtype: 1, Class: 1, Ttl: 1}, A: net.ParseIP("0.0.0.0")}}
+	msg.Answer = []dns.RR{&dns.A{Hdr: dns.RR_Header{Name: "test", Rrtype: 1, Class: 1, Ttl: 1}, A: net.ParseIP("0.0.0.0")}}
+	msg.Ns = []dns.RR{&dns.A{Hdr: dns.RR_Header{Name: "test", Rrtype: 1, Class: 1, Ttl: 1}, A: net.ParseIP("0.0.0.0")}}
+	m := DNSToMap(&msg, "")
+	require.NotNil(t, m)
+	require.NotEmpty(t, m)
+}

--- a/maps/mapsutil.go
+++ b/maps/mapsutil.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/miekg/dns"
 	"golang.org/x/exp/constraints"
 	extmaps "golang.org/x/exp/maps"
 )
@@ -57,49 +56,6 @@ func HTTPToMap(resp *http.Response, body, headers string, duration time.Duration
 
 	// Converts duration to seconds (floating point) for DSL syntax
 	m[fmt.Sprintf(format, "duration")] = duration.Seconds()
-
-	return m
-}
-
-// DNSToMap Converts DNS to Matcher Map
-func DNSToMap(msg *dns.Msg, format string) (m map[string]interface{}) {
-	m = make(map[string]interface{})
-
-	if format == "" {
-		format = defaultFormat
-	}
-
-	m[fmt.Sprintf(format, "rcode")] = msg.Rcode
-
-	var qs string
-
-	for _, question := range msg.Question {
-		qs += fmt.Sprintln(question.String())
-	}
-
-	m[fmt.Sprintf(format, "question")] = qs
-
-	var exs string
-	for _, extra := range msg.Extra {
-		exs += fmt.Sprintln(extra.String())
-	}
-
-	m[fmt.Sprintf(format, "extra")] = exs
-
-	var ans string
-	for _, answer := range msg.Answer {
-		ans += fmt.Sprintln(answer.String())
-	}
-
-	m[fmt.Sprintf(format, "answer")] = ans
-
-	var nss string
-	for _, ns := range msg.Ns {
-		nss += fmt.Sprintln(ns.String())
-	}
-
-	m[fmt.Sprintf(format, "ns")] = nss
-	m[fmt.Sprintf(format, "raw")] = msg.String()
 
 	return m
 }

--- a/maps/mapsutil_test.go
+++ b/maps/mapsutil_test.go
@@ -3,14 +3,12 @@ package mapsutil
 import (
 	"crypto/tls"
 	"io"
-	"net"
 	"net/http"
 	"net/url"
 	"strings"
 	"testing"
 	"time"
 
-	"github.com/miekg/dns"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/maps"
 )
@@ -80,18 +78,6 @@ func TestHTTPToMap(t *testing.T) {
 
 	m := HTTPToMap(resp, bufBody.String(), bufHeaders.String(), time.Duration(2), "")
 
-	require.NotNil(t, m)
-	require.NotEmpty(t, m)
-}
-
-func TestDNSToMap(t *testing.T) {
-	msg := dns.Msg{}
-	msg.Rcode = 1
-	msg.Question = []dns.Question{{Name: "test", Qtype: 1, Qclass: 1}}
-	msg.Extra = []dns.RR{&dns.A{Hdr: dns.RR_Header{Name: "test", Rrtype: 1, Class: 1, Ttl: 1}, A: net.ParseIP("0.0.0.0")}}
-	msg.Answer = []dns.RR{&dns.A{Hdr: dns.RR_Header{Name: "test", Rrtype: 1, Class: 1, Ttl: 1}, A: net.ParseIP("0.0.0.0")}}
-	msg.Ns = []dns.RR{&dns.A{Hdr: dns.RR_Header{Name: "test", Rrtype: 1, Class: 1, Ttl: 1}, A: net.ParseIP("0.0.0.0")}}
-	m := DNSToMap(&msg, "")
 	require.NotNil(t, m)
 	require.NotEmpty(t, m)
 }


### PR DESCRIPTION
DNSToMap lived in the generic mapsutil package, which meant it pulled github.com/miekg/dns into maps. Since goflags imports mapsutil and almost every tool imports goflags, the whole dns record method set ended up linked into nearly every binary, even the ones that never touch DNS.

Moving DNSToMap into its own utils/maps/dnsmap package isolates the dns dependency so only code that actually converts DNS messages links it.

Measured on a tiny program that just parses flags through goflags, the dns code symbols drop from 1010 to 0 and the stripped binary goes from 7.66 MB to 6.17 MB, about 1.5 MB smaller across the board.

Callers should switch from mapsutil.DNSToMap to dnsmap.DNSToMap. There are no usages of it across the projectdiscovery repos today.