### PR TITLE
Fix UpdatePort corrupting the host when the port digits appear inside the host/IP

### DIFF
--- a/url/url.go
+++ b/url/url.go
@@ -2,6 +2,7 @@ package urlutil
 
 import (
 	"bytes"
+	"net"
 	"net/url"
 	"strings"
 
@@ -146,11 +147,7 @@ func (u *URL) UpdatePort(newport string) {
 	if newport == "" {
 		return
 	}
-	if u.Port() != "" {
-		u.Host = strings.Replace(u.Host, u.Port(), newport, 1)
-		return
-	}
-	u.Host += ":" + newport
+	u.Host = net.JoinHostPort(u.Hostname(), newport)
 }
 
 // TrimPort if any

--- a/url/url_test.go
+++ b/url/url_test.go
@@ -82,6 +82,27 @@ func TestPortUpdate(t *testing.T) {
 	require.Equalf(t, urlx.String(), expected, "expected %v but got %v", expected, urlx.String())
 }
 
+func TestPortUpdateWhenPortMatchesHost(t *testing.T) {
+	// UpdatePort uses strings.Replace on the whole Host, so the port substring
+	// can accidentally match a piece of the IP/hostname instead of the actual port.
+	testcases := []struct {
+		inputURL string
+		newport  string
+		expected string
+	}{
+		// last octet "80" matches before the real ":80" port
+		{"http://37.228.93.80:80/", "443", "http://37.228.93.80:443/"},
+		{"http://37.228.93.443:80/", "8080", "http://37.228.93.443:8080/"},
+		{"http://[2001:db8::80]:80/", "8080", "http://[2001:db8::80]:8080/"},
+	}
+	for _, tc := range testcases {
+		urlx, err := Parse(tc.inputURL)
+		require.Nil(t, err)
+		urlx.UpdatePort(tc.newport)
+		require.Equalf(t, tc.expected, urlx.String(), "expected %v but got %v", tc.expected, urlx.String())
+	}
+}
+
 func TestUpdateRelPath(t *testing.T) {
 	// updates existing relative path with new one
 	exURL := "https://scanme.sh/somepath/abc?key=true"


### PR DESCRIPTION
Closes #753
## Fix UpdatePort corrupting the host when the port digits appear inside the host/IP

### Problem
`URL.UpdatePort` replaced the port via `strings.Replace(u.Host, u.Port(), newport, 1)`,
which swaps the **first** occurrence of the port substring in the host — not the actual
port. When the port digits also appear inside the IP/hostname, the wrong part gets rewritten.

Examples:
- `http://37.228.93.80:80/` + `UpdatePort("443")` → `http://37.228.93.443:80/` ❌
- `http://[2001:db8::80]:80/` + `UpdatePort("8080")` → `http://[2001:db8::8080]:80/` ❌

### Fix
Build the host with `net.JoinHostPort(u.Hostname(), newport)`. `Hostname()` strips the
existing port and unwraps IPv6 brackets, and `JoinHostPort` re-wraps IPv6 literals
correctly — so the port is always set on the right segment.

### Tests
Added `TestPortUpdateWhenPortMatchesHost` covering IPv4 and IPv6 cases that previously
produced a corrupted host.
