### PR TITLE
Add chromeshell package for linux amd64

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: projectdiscovery/actions/setup/go@v1
-      - uses: projectdiscovery/actions/golangci-lint@v1
+      - uses: projectdiscovery/actions/golangci-lint/v2@v1
 
   build:
     name: Test Builds

--- a/chromeshell/chromeshell.go
+++ b/chromeshell/chromeshell.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"strings"
 	"sync"
 )
 
@@ -123,7 +122,7 @@ func downloadAndExtract(url, destDir string) error {
 	if err != nil {
 		return err
 	}
-	defer os.RemoveAll(tmpDir)
+	defer func() { _ = os.RemoveAll(tmpDir) }()
 
 	zipPath := filepath.Join(tmpDir, "chrome-headless-shell.zip")
 	if err := downloadFile(url, zipPath); err != nil {
@@ -153,7 +152,7 @@ func downloadFile(url, dest string) error {
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("download %s: unexpected status %s", url, resp.Status)
@@ -163,7 +162,7 @@ func downloadFile(url, dest string) error {
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	_, err = io.Copy(f, resp.Body)
 	return err
@@ -174,17 +173,19 @@ func unzip(zipPath, dest string) error {
 	if err != nil {
 		return err
 	}
-	defer r.Close()
+	defer func() { _ = r.Close() }()
 
 	if err := os.MkdirAll(dest, 0o755); err != nil {
 		return err
 	}
 
 	for _, f := range r.File {
-		target, err := safeJoin(dest, f.Name)
-		if err != nil {
-			return err
+		// entry names must stay inside dest: reject "..", absolute paths and
+		// other non-local names before joining
+		if !filepath.IsLocal(f.Name) {
+			return fmt.Errorf("illegal path in zip: %s", f.Name)
 		}
+		target := filepath.Join(dest, f.Name)
 		if f.FileInfo().IsDir() {
 			if err := os.MkdirAll(target, 0o755); err != nil {
 				return err
@@ -206,7 +207,7 @@ func writeZipFile(f *zip.File, target string) error {
 	if err != nil {
 		return err
 	}
-	defer rc.Close()
+	defer func() { _ = rc.Close() }()
 
 	mode := f.Mode()
 	if mode&0o111 != 0 {
@@ -219,7 +220,7 @@ func writeZipFile(f *zip.File, target string) error {
 	if err != nil {
 		return err
 	}
-	defer out.Close()
+	defer func() { _ = out.Close() }()
 
 	_, err = io.Copy(out, rc)
 	return err
@@ -240,13 +241,4 @@ func stripFirstDir(dir string) (string, error) {
 		return dirs[0], nil
 	}
 	return dir, nil
-}
-
-func safeJoin(base, name string) (string, error) {
-	target := filepath.Clean(filepath.Join(base, name))
-	baseClean := filepath.Clean(base) + string(os.PathSeparator)
-	if target != filepath.Clean(base) && !strings.HasPrefix(target+string(os.PathSeparator), baseClean) {
-		return "", fmt.Errorf("illegal path in zip: %s", name)
-	}
-	return target, nil
 }

--- a/chromeshell/chromeshell.go
+++ b/chromeshell/chromeshell.go
@@ -1,0 +1,252 @@
+package chromeshell
+
+import (
+	"archive/zip"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+)
+
+const (
+	// Version is the pinned Chrome for Testing chrome-headless-shell build.
+	// Smaller and faster than full Chromium for headless screenshots on Linux.
+	Version = "152.0.7977.42"
+
+	// revision is a synthetic cache key under the rod browser cache layout so
+	// existing go-rod consumers share the same on-disk location.
+	revision = 1520797742
+)
+
+var ensureMu sync.Mutex
+
+// Supported reports whether chrome-headless-shell auto-download is available
+// for the current platform.
+func Supported() bool {
+	return runtime.GOOS == "linux" && runtime.GOARCH == "amd64"
+}
+
+// Host returns the Chrome for Testing chrome-headless-shell zip URL for
+// linux/amd64. Other platforms should not use this host for downloads.
+func Host() string {
+	return fmt.Sprintf(
+		"https://storage.googleapis.com/chrome-for-testing-public/%s/linux64/chrome-headless-shell-linux64.zip",
+		Version,
+	)
+}
+
+// HostChromeShell is a go-rod launcher.Host-compatible adapter that ignores the
+// revision argument and always returns the pinned chrome-headless-shell URL.
+func HostChromeShell(_ int) string {
+	return Host()
+}
+
+// Dir returns the on-disk cache directory for the pinned chrome-headless-shell.
+func Dir() string {
+	return filepath.Join(defaultBrowserDir(), fmt.Sprintf("chromium-%d", revision))
+}
+
+// BinPath returns the preferred executable path inside Dir, if present.
+func BinPath() string {
+	return findBin(Dir())
+}
+
+// Ensure downloads chrome-headless-shell once into the shared browser cache and
+// returns the executable path. It is a no-op download when the binary already
+// exists. Callers should only invoke this when Supported() is true.
+func Ensure() (string, error) {
+	if !Supported() {
+		return "", fmt.Errorf("chrome-headless-shell auto-download is only supported on linux/amd64")
+	}
+
+	ensureMu.Lock()
+	defer ensureMu.Unlock()
+
+	if p := findBin(Dir()); p != "" {
+		return p, nil
+	}
+
+	if err := downloadAndExtract(Host(), Dir()); err != nil {
+		return "", err
+	}
+
+	p := findBin(Dir())
+	if p == "" {
+		return "", fmt.Errorf("chrome-headless-shell binary missing after download in %s", Dir())
+	}
+
+	// go-rod's linux BinPath expects "chrome"; keep a symlink for Validate().
+	chrome := filepath.Join(Dir(), "chrome")
+	if p != chrome {
+		_ = os.Remove(chrome)
+		_ = os.Symlink(filepath.Base(p), chrome)
+	}
+
+	return p, nil
+}
+
+func findBin(dir string) string {
+	for _, name := range []string{"chrome-headless-shell", "headless_shell", "chrome"} {
+		p := filepath.Join(dir, name)
+		if fi, err := os.Stat(p); err == nil && !fi.IsDir() {
+			return p
+		}
+	}
+	return ""
+}
+
+func defaultBrowserDir() string {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		home = os.TempDir()
+	}
+	switch runtime.GOOS {
+	case "windows":
+		if appdata := os.Getenv("APPDATA"); appdata != "" {
+			return filepath.Join(appdata, "rod", "browser")
+		}
+	}
+	return filepath.Join(home, ".cache", "rod", "browser")
+}
+
+func downloadAndExtract(url, destDir string) error {
+	tmpParent := filepath.Dir(destDir)
+	if err := os.MkdirAll(tmpParent, 0o755); err != nil {
+		return err
+	}
+
+	tmpDir, err := os.MkdirTemp(tmpParent, "chrome-headless-shell-*")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(tmpDir)
+
+	zipPath := filepath.Join(tmpDir, "chrome-headless-shell.zip")
+	if err := downloadFile(url, zipPath); err != nil {
+		return err
+	}
+
+	extractDir := filepath.Join(tmpDir, "extract")
+	if err := unzip(zipPath, extractDir); err != nil {
+		return err
+	}
+
+	// Chrome for Testing zips nest files under one top-level directory.
+	contentDir, err := stripFirstDir(extractDir)
+	if err != nil {
+		return err
+	}
+
+	_ = os.RemoveAll(destDir)
+	if err := os.Rename(contentDir, destDir); err != nil {
+		return err
+	}
+	return nil
+}
+
+func downloadFile(url, dest string) error {
+	resp, err := http.Get(url) //nolint:noctx // one-shot browser binary fetch
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("download %s: unexpected status %s", url, resp.Status)
+	}
+
+	f, err := os.Create(dest)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	_, err = io.Copy(f, resp.Body)
+	return err
+}
+
+func unzip(zipPath, dest string) error {
+	r, err := zip.OpenReader(zipPath)
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+
+	if err := os.MkdirAll(dest, 0o755); err != nil {
+		return err
+	}
+
+	for _, f := range r.File {
+		target, err := safeJoin(dest, f.Name)
+		if err != nil {
+			return err
+		}
+		if f.FileInfo().IsDir() {
+			if err := os.MkdirAll(target, 0o755); err != nil {
+				return err
+			}
+			continue
+		}
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			return err
+		}
+		if err := writeZipFile(f, target); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func writeZipFile(f *zip.File, target string) error {
+	rc, err := f.Open()
+	if err != nil {
+		return err
+	}
+	defer rc.Close()
+
+	mode := f.Mode()
+	if mode&0o111 != 0 {
+		mode = 0o755
+	} else {
+		mode = 0o644
+	}
+
+	out, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	_, err = io.Copy(out, rc)
+	return err
+}
+
+func stripFirstDir(dir string) (string, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return "", err
+	}
+	var dirs []string
+	for _, e := range entries {
+		if e.IsDir() {
+			dirs = append(dirs, filepath.Join(dir, e.Name()))
+		}
+	}
+	if len(dirs) == 1 && len(entries) == 1 {
+		return dirs[0], nil
+	}
+	return dir, nil
+}
+
+func safeJoin(base, name string) (string, error) {
+	target := filepath.Clean(filepath.Join(base, name))
+	baseClean := filepath.Clean(base) + string(os.PathSeparator)
+	if target != filepath.Clean(base) && !strings.HasPrefix(target+string(os.PathSeparator), baseClean) {
+		return "", fmt.Errorf("illegal path in zip: %s", name)
+	}
+	return target, nil
+}

--- a/chromeshell/chromeshell_test.go
+++ b/chromeshell/chromeshell_test.go
@@ -1,11 +1,32 @@
 package chromeshell
 
 import (
+	"archive/zip"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 )
+
+func writeTestZip(path string, entries map[string]string) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+
+	w := zip.NewWriter(f)
+	for name, content := range entries {
+		e, err := w.Create(name)
+		if err != nil {
+			return err
+		}
+		if _, err := e.Write([]byte(content)); err != nil {
+			return err
+		}
+	}
+	return w.Close()
+}
 
 func TestHost(t *testing.T) {
 	u := Host()
@@ -35,17 +56,33 @@ func TestFindBin(t *testing.T) {
 	}
 }
 
-func TestSafeJoin(t *testing.T) {
-	base := t.TempDir()
-	if _, err := safeJoin(base, "../evil"); err == nil {
-		t.Fatal("expected error for path escape")
-	}
-	got, err := safeJoin(base, "chrome-headless-shell")
-	if err != nil {
+func TestUnzipRejectsPathEscape(t *testing.T) {
+	dir := t.TempDir()
+	zipPath := filepath.Join(dir, "evil.zip")
+	if err := writeTestZip(zipPath, map[string]string{
+		"../evil": "x",
+	}); err != nil {
 		t.Fatal(err)
 	}
-	if got != filepath.Join(base, "chrome-headless-shell") {
-		t.Fatalf("got %q", got)
+	if err := unzip(zipPath, filepath.Join(dir, "out")); err == nil {
+		t.Fatal("expected error for path escape")
+	}
+}
+
+func TestUnzipExtractsLocalEntries(t *testing.T) {
+	dir := t.TempDir()
+	zipPath := filepath.Join(dir, "ok.zip")
+	if err := writeTestZip(zipPath, map[string]string{
+		"chrome-headless-shell": "x",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	out := filepath.Join(dir, "out")
+	if err := unzip(zipPath, out); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(out, "chrome-headless-shell")); err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/chromeshell/chromeshell_test.go
+++ b/chromeshell/chromeshell_test.go
@@ -1,0 +1,59 @@
+package chromeshell
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestHost(t *testing.T) {
+	u := Host()
+	if !strings.Contains(u, "chrome-for-testing-public/"+Version+"/") {
+		t.Fatalf("unexpected host url: %s", u)
+	}
+	if !strings.HasSuffix(u, "/linux64/chrome-headless-shell-linux64.zip") {
+		t.Fatalf("unexpected zip path: %s", u)
+	}
+	if HostChromeShell(0) != u {
+		t.Fatalf("HostChromeShell mismatch")
+	}
+}
+
+func TestFindBin(t *testing.T) {
+	dir := t.TempDir()
+	if got := findBin(dir); got != "" {
+		t.Fatalf("expected empty, got %q", got)
+	}
+
+	shell := filepath.Join(dir, "chrome-headless-shell")
+	if err := os.WriteFile(shell, []byte("x"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if got := findBin(dir); got != shell {
+		t.Fatalf("got %q want %q", got, shell)
+	}
+}
+
+func TestSafeJoin(t *testing.T) {
+	base := t.TempDir()
+	if _, err := safeJoin(base, "../evil"); err == nil {
+		t.Fatal("expected error for path escape")
+	}
+	got, err := safeJoin(base, "chrome-headless-shell")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != filepath.Join(base, "chrome-headless-shell") {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestEnsureUnsupported(t *testing.T) {
+	if Supported() {
+		t.Skip("linux/amd64 supports download")
+	}
+	if _, err := Ensure(); err == nil {
+		t.Fatal("expected unsupported error")
+	}
+}

--- a/ml/metrics/classification_report.go
+++ b/ml/metrics/classification_report.go
@@ -7,10 +7,10 @@ import (
 
 func (cm *ConfusionMatrix) PrintClassificationReport() string {
 	var s strings.Builder
-	s.WriteString(fmt.Sprintf("%30s\n", "Classification Report"))
-	s.WriteString(fmt.Sprintln())
+	fmt.Fprintf(&s, "%30s\n", "Classification Report")
+	fmt.Fprintln(&s)
 
-	s.WriteString(fmt.Sprintf("\n%-15s %-10s %-10s %-10s %-10s\n", "", "precision", "recall", "f1-score", "support"))
+	fmt.Fprintf(&s, "\n%-15s %-10s %-10s %-10s %-10s\n", "", "precision", "recall", "f1-score", "support")
 
 	totals := map[string]float64{"true": 0, "predicted": 0, "correct": 0}
 	macroAvg := map[string]float64{"precision": 0, "recall": 0, "f1-score": 0}
@@ -42,22 +42,22 @@ func (cm *ConfusionMatrix) PrintClassificationReport() string {
 	}
 
 	accuracy := totals["correct"] / totals["true"]
-	s.WriteString(fmt.Sprintf("\n%-26s %-10s %-10.2f %-10d", "accuracy", "", accuracy, int(totals["true"])))
+	fmt.Fprintf(&s, "\n%-26s %-10s %-10.2f %-10d", "accuracy", "", accuracy, int(totals["true"]))
 
-	s.WriteString(fmt.Sprintf("\n%-15s %-10.2f %-10.2f %-10.2f %-10d\n", "macro avg",
+	fmt.Fprintf(&s, "\n%-15s %-10.2f %-10.2f %-10.2f %-10d\n", "macro avg",
 		macroAvg["precision"]/float64(len(cm.labels)),
 		macroAvg["recall"]/float64(len(cm.labels)),
 		macroAvg["f1-score"]/float64(len(cm.labels)),
-		int(totals["true"])))
+		int(totals["true"]))
 
 	precisionWeightedAvg := totals["correct"] / totals["predicted"]
 	recallWeightedAvg := totals["correct"] / totals["true"]
 	f1ScoreWeightedAvg := 2 * precisionWeightedAvg * recallWeightedAvg / (precisionWeightedAvg + recallWeightedAvg)
 
-	s.WriteString(fmt.Sprintf("%-15s %-10.2f %-10.2f %-10.2f %-10d\n", "weighted avg",
-		precisionWeightedAvg, recallWeightedAvg, f1ScoreWeightedAvg, int(totals["true"])))
+	fmt.Fprintf(&s, "%-15s %-10.2f %-10.2f %-10.2f %-10d\n", "weighted avg",
+		precisionWeightedAvg, recallWeightedAvg, f1ScoreWeightedAvg, int(totals["true"]))
 
-	s.WriteString(fmt.Sprintln())
+	fmt.Fprintln(&s)
 
 	return s.String()
 }

--- a/ml/metrics/confusion_matrix.go
+++ b/ml/metrics/confusion_matrix.go
@@ -35,24 +35,24 @@ func NewConfusionMatrix(actual, predicted []string, labels []string) *ConfusionM
 func (cm *ConfusionMatrix) PrintConfusionMatrix() string {
 	var s strings.Builder
 
-	s.WriteString(fmt.Sprintf("%30s\n", "Confusion Matrix"))
-	s.WriteString(fmt.Sprintln())
+	fmt.Fprintf(&s, "%30s\n", "Confusion Matrix")
+	fmt.Fprintln(&s)
 	// Print header
-	s.WriteString(fmt.Sprintf("%-15s", ""))
+	fmt.Fprintf(&s, "%-15s", "")
 	for _, label := range cm.labels {
-		s.WriteString(fmt.Sprintf("%-15s", label))
+		fmt.Fprintf(&s, "%-15s", label)
 	}
-	s.WriteString(fmt.Sprintln())
+	fmt.Fprintln(&s)
 
 	// Print rows
 	for i, row := range cm.matrix {
-		s.WriteString(fmt.Sprintf("%-15s", cm.labels[i]))
+		fmt.Fprintf(&s, "%-15s", cm.labels[i])
 		for _, value := range row {
-			s.WriteString(fmt.Sprintf("%-15d", value))
+			fmt.Fprintf(&s, "%-15d", value)
 		}
-		s.WriteString(fmt.Sprintln())
+		fmt.Fprintln(&s)
 	}
-	s.WriteString(fmt.Sprintln())
+	fmt.Fprintln(&s)
 
 	return s.String()
 }

--- a/reflect/reflectutil.go
+++ b/reflect/reflectutil.go
@@ -38,7 +38,7 @@ func ToMap(v interface{}, tomapkey ToMapKey, unexported bool) (map[string]interf
 	typ := reflect.TypeOf(v)
 	val := reflect.ValueOf(v)
 	switch typ.Kind() {
-	case reflect.Ptr:
+	case reflect.Pointer:
 		typ = typ.Elem()
 	}
 	if typ.Kind() != reflect.Struct {
@@ -175,7 +175,7 @@ func sizeOf(v reflect.Value, cache map[uintptr]bool) int {
 		cache[stringPtr] = true
 		return len(s) + int(v.Type().Size())
 
-	case reflect.Ptr:
+	case reflect.Pointer:
 		// return Ptr size if this node has been visited already (infinite recursion)
 		if cache[v.Pointer()] {
 			return int(v.Type().Size())

--- a/strings/stringsutil.go
+++ b/strings/stringsutil.go
@@ -108,10 +108,10 @@ func Join(elems []interface{}, sep string) string {
 
 	var b strings.Builder
 	b.Grow(n)
-	b.WriteString(fmt.Sprint(elems[0]))
+	fmt.Fprint(&b, elems[0])
 	for _, s := range elems[1:] {
 		b.WriteString(sep)
-		b.WriteString(fmt.Sprint(s))
+		fmt.Fprint(&b, s)
 	}
 	return b.String()
 }

--- a/structs/structs.go
+++ b/structs/structs.go
@@ -20,7 +20,7 @@ type CallbackFunc func(reflect.Value, reflect.StructField)
 // The interface{} passed to the function should be a pointer to a struct
 func Walk(s interface{}, callback CallbackFunc) {
 	structValue := reflect.ValueOf(s)
-	if structValue.Kind() == reflect.Ptr {
+	if structValue.Kind() == reflect.Pointer {
 		structValue = structValue.Elem()
 	}
 	if structValue.Kind() != reflect.Struct {
@@ -34,7 +34,7 @@ func Walk(s interface{}, callback CallbackFunc) {
 		}
 		if field.Kind() == reflect.Struct {
 			Walk(field.Addr().Interface(), callback)
-		} else if field.Kind() == reflect.Ptr && field.Elem().Kind() == reflect.Struct {
+		} else if field.Kind() == reflect.Pointer && field.Elem().Kind() == reflect.Struct {
 			Walk(field.Interface(), callback)
 		} else {
 			callback(field, fieldType)
@@ -44,7 +44,7 @@ func Walk(s interface{}, callback CallbackFunc) {
 
 func walkFilteredFields[T any](input T, includeFields, excludeFields []string, walker func(field reflect.StructField, value reflect.Value)) error {
 	val := reflect.ValueOf(input)
-	if val.Kind() == reflect.Ptr {
+	if val.Kind() == reflect.Pointer {
 		val = val.Elem()
 	}
 	if val.Kind() != reflect.Struct {
@@ -85,7 +85,7 @@ func walkFilteredFields[T any](input T, includeFields, excludeFields []string, w
 func FilterStruct[T any](input T, includeFields, excludeFields []string) (T, error) {
 	var zeroValue T
 	val := reflect.ValueOf(input)
-	if val.Kind() == reflect.Ptr {
+	if val.Kind() == reflect.Pointer {
 		val = val.Elem()
 	}
 
@@ -133,7 +133,7 @@ func FilterStructToMap[T any](input T, includeFields, excludeFields []string) (*
 // Returns a slice of field names or an error if the input is not a struct.
 func GetStructFields[T any](input T) ([]string, error) {
 	val := reflect.ValueOf(input)
-	if val.Kind() == reflect.Ptr {
+	if val.Kind() == reflect.Pointer {
 		val = val.Elem()
 	}
 


### PR DESCRIPTION
Shared helper that stages Chrome for Testing chrome-headless-shell on linux/amd64 so httpx, katana, and nuclei can reuse the same download path. Closes #763.