### PR TITLE
fix(ci): patch-bump on any commits in Bump Version workflow

### DIFF
--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -13,7 +13,16 @@ jobs:
         with:
           fetch-depth: 0
       - uses: projectdiscovery/actions/setup/git@v1
+      # always: true patch-bumps when commits exist but are not conventional.
+      # Skip when HEAD is already the latest tag so empty weeks do not ship.
+      - id: on-tag
+        run: |
+          if git describe --exact-match --tags HEAD >/dev/null 2>&1; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          fi
+        shell: bash
       - uses: projectdiscovery/actions/svu-next@v1
+        if: steps.on-tag.outputs.skip != 'true'
         with:
           v0: true
           always: true

--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -16,4 +16,5 @@ jobs:
       - uses: projectdiscovery/actions/svu-next@v1
         with:
           v0: true
+          always: true
           release-create: true


### PR DESCRIPTION
Fixes #765

The weekly bump has not released since `v0.11.1`, despite 19 commits on `main`. `svu` bumps from conventional-commit subjects and none of those commits carry one — `chore(deps):` does not bump, merge commits are not conventional, and PR titles never reach `main` because PRs land as merges rather than squashes. So `svu next` returns the current version and nothing ships.

`always: true` supplies a patch floor when no commit triggers a bump. `feat:`/`fix:`/breaking commits still take precedence and bump minor/major exactly as before; weeks with no commits at all still no-op.

Dependency and hardening changes in a library every PD tool consumes should ship — `91e10ed harden unzip` and five weeks of dependabot bumps are currently sitting untagged.

The misleading `##[warning]Reference already exists` on the green job is a separate bug in the action: projectdiscovery/actions#106, fix in projectdiscovery/actions#107.