### PR TITLE
fix(process): register interrupt handler before raising in windows test

### DIFF
--- a/process/interrupt_windows_test.go
+++ b/process/interrupt_windows_test.go
@@ -5,8 +5,12 @@ package process
 import (
 	"os"
 	"os/exec"
+	"os/signal"
 	"syscall"
 	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestSendInterrupt(t *testing.T) {
@@ -14,7 +18,22 @@ func TestSendInterrupt(t *testing.T) {
 	// stays isolated and does not kill sibling processes (e.g. the Go
 	// compiler running in parallel during "go test ./...").
 	if os.Getenv("TEST_SEND_INTERRUPT_CHILD") == "1" {
+		// Register before raising: the runtime turns CTRL_BREAK_EVENT into
+		// SIGINT only when something is watching for it, otherwise the console
+		// default action terminates this process with STATUS_CONTROL_C_EXIT
+		// (0xc000013a) and the parent sees a failed child.
+		sigChan := make(chan os.Signal, 1)
+		signal.Notify(sigChan, os.Interrupt)
+		defer signal.Stop(sigChan)
+
 		SendInterrupt()
+
+		select {
+		case sig := <-sigChan:
+			require.Equal(t, os.Interrupt, sig)
+		case <-time.After(2 * time.Second):
+			t.Fatal("timeout waiting for interrupt signal")
+		}
 		return
 	}
 


### PR DESCRIPTION
Fixes #767

`TestSendInterrupt` is flaky on `windows-latest`, and as written it is green only when `SendInterrupt` is *too slow* to matter.

The child branch raised the event with nothing watching `SIGINT`:

```go
if os.Getenv("TEST_SEND_INTERRUPT_CHILD") == "1" {
    SendInterrupt()
    return
}
```

`runtime.ctrlHandler` maps `CTRL_BREAK_EVENT` to `SIGINT` but only consumes it when a handler is registered (`if sigsend(s) { return 1 }`). With no handler it returns 0 and Windows runs the default action — terminate with `STATUS_CONTROL_C_EXIT` (`0xc000013a`). Delivery is asynchronous, so it was a race between the handler thread and the child's `return`; the failing log shows the child emitting both `PASS` and `exit status 0xc000013a`.

This registers `signal.Notify` before raising and waits for the signal, matching what `interrupt_unix_test.go` already does. The race is gone (the handler consumes the event instead of the default action) and the test now asserts the thing it is named after. The parent-side re-exec with `CREATE_NEW_PROCESS_GROUP` is untouched — that is what keeps the break event away from sibling processes during `go test ./...`.

`GOOS=windows go vet ./process/` is clean; the behaviour itself needs the Windows runner to confirm, so watch this PR's `Test Builds (windows-latest)` job.