### PR TITLE
Bound chrome-headless-shell downloads

### DIFF
--- a/chromeshell/chromeshell.go
+++ b/chromeshell/chromeshell.go
@@ -2,13 +2,13 @@ package chromeshell
 
 import (
 	"archive/zip"
+	"context"
 	"fmt"
 	"io"
 	"net/http"
 	"os"
 	"path/filepath"
 	"runtime"
-	"sync"
 )
 
 const (
@@ -21,7 +21,11 @@ const (
 	revision = 1520797742
 )
 
-var ensureMu sync.Mutex
+var ensureLock = func() chan struct{} {
+	lock := make(chan struct{}, 1)
+	lock <- struct{}{}
+	return lock
+}()
 
 // Supported reports whether chrome-headless-shell auto-download is available
 // for the current platform.
@@ -58,18 +62,28 @@ func BinPath() string {
 // returns the executable path. It is a no-op download when the binary already
 // exists. Callers should only invoke this when Supported() is true.
 func Ensure() (string, error) {
+	return EnsureContext(context.Background())
+}
+
+// EnsureContext is like Ensure, but stops waiting for the shared download lock
+// and cancels the browser download when ctx is done.
+func EnsureContext(ctx context.Context) (string, error) {
 	if !Supported() {
 		return "", fmt.Errorf("chrome-headless-shell auto-download is only supported on linux/amd64")
 	}
 
-	ensureMu.Lock()
-	defer ensureMu.Unlock()
+	select {
+	case <-ctx.Done():
+		return "", ctx.Err()
+	case <-ensureLock:
+		defer func() { ensureLock <- struct{}{} }()
+	}
 
 	if p := findBin(Dir()); p != "" {
 		return p, nil
 	}
 
-	if err := downloadAndExtract(Host(), Dir()); err != nil {
+	if err := downloadAndExtract(ctx, Host(), Dir()); err != nil {
 		return "", err
 	}
 
@@ -112,7 +126,7 @@ func defaultBrowserDir() string {
 	return filepath.Join(home, ".cache", "rod", "browser")
 }
 
-func downloadAndExtract(url, destDir string) error {
+func downloadAndExtract(ctx context.Context, url, destDir string) error {
 	tmpParent := filepath.Dir(destDir)
 	if err := os.MkdirAll(tmpParent, 0o755); err != nil {
 		return err
@@ -125,7 +139,7 @@ func downloadAndExtract(url, destDir string) error {
 	defer func() { _ = os.RemoveAll(tmpDir) }()
 
 	zipPath := filepath.Join(tmpDir, "chrome-headless-shell.zip")
-	if err := downloadFile(url, zipPath); err != nil {
+	if err := downloadFile(ctx, url, zipPath); err != nil {
 		return err
 	}
 
@@ -147,8 +161,12 @@ func downloadAndExtract(url, destDir string) error {
 	return nil
 }
 
-func downloadFile(url, dest string) error {
-	resp, err := http.Get(url) //nolint:noctx // one-shot browser binary fetch
+func downloadFile(ctx context.Context, url, dest string) error {
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := http.DefaultClient.Do(request)
 	if err != nil {
 		return err
 	}

--- a/chromeshell/chromeshell_test.go
+++ b/chromeshell/chromeshell_test.go
@@ -2,10 +2,15 @@ package chromeshell
 
 import (
 	"archive/zip"
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func writeTestZip(path string, entries map[string]string) error {
@@ -92,5 +97,35 @@ func TestEnsureUnsupported(t *testing.T) {
 	}
 	if _, err := Ensure(); err == nil {
 		t.Fatal("expected unsupported error")
+	}
+}
+
+func TestDownloadFileContextCancellation(t *testing.T) {
+	requestDone := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer close(requestDone)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("partial"))
+		w.(http.Flusher).Flush()
+		<-r.Context().Done()
+	}))
+	t.Cleanup(server.Close)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	started := time.Now()
+	err := downloadFile(ctx, server.URL, filepath.Join(t.TempDir(), "browser.zip"))
+
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected context deadline exceeded, got %v", err)
+	}
+	if elapsed := time.Since(started); elapsed > time.Second {
+		t.Fatalf("download cancellation took %s", elapsed)
+	}
+	select {
+	case <-requestDone:
+	case <-time.After(time.Second):
+		t.Fatal("server request did not observe cancellation")
 	}
 }

--- a/reader/conn_read_cancel_test.go
+++ b/reader/conn_read_cancel_test.go
@@ -67,7 +67,7 @@ func TestConnReadN_ReturnsPartialDataOnCancel(t *testing.T) {
 		if err != nil {
 			return
 		}
-		defer c.Close()
+		defer func() { _ = c.Close() }()
 		_, _ = c.Write([]byte("hi"))  // send partial data, then stall
 		_, _ = io.Copy(io.Discard, c) // block until the client closes
 	}()

--- a/reader/conn_read_cancel_test.go
+++ b/reader/conn_read_cancel_test.go
@@ -18,8 +18,6 @@ import (
 // stays parked in Read for the connection's lifetime, leaking the goroutine,
 // its buffers, and the connection on every cancelled read.
 func TestConnReadN_NoGoroutineLeakOnCancel(t *testing.T) {
-	addr := newSilentServer(t)
-
 	runtime.GC()
 	time.Sleep(50 * time.Millisecond)
 	runtime.GC()
@@ -27,14 +25,12 @@ func TestConnReadN_NoGoroutineLeakOnCancel(t *testing.T) {
 
 	const calls = 50
 	for range calls {
-		conn, err := net.Dial("tcp", addr)
-		if err != nil {
-			t.Fatal(err)
-		}
+		conn, peer := net.Pipe()
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Millisecond)
 		_, _ = ConnReadN(ctx, conn, 16) // peer sends nothing; ctx expires first
 		cancel()
-		t.Cleanup(func() { _ = conn.Close() })
+		_ = conn.Close()
+		_ = peer.Close()
 	}
 
 	deadline := time.Now().Add(5 * time.Second)
@@ -89,27 +85,4 @@ func TestConnReadN_ReturnsPartialDataOnCancel(t *testing.T) {
 	if string(data) != "hi" {
 		t.Fatalf("expected %q, got %q", "hi", string(data))
 	}
-}
-
-// newSilentServer returns the address of a TCP server that accepts connections
-// and holds them open without ever writing, so reads against it block until the
-// reader's deadline or close.
-func newSilentServer(t *testing.T) string {
-	t.Helper()
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatal(err)
-	}
-	held := make(chan net.Conn, 1024)
-	go func() {
-		for {
-			c, err := ln.Accept()
-			if err != nil {
-				return
-			}
-			held <- c // hold the server end open; never write
-		}
-	}()
-	t.Cleanup(func() { _ = ln.Close() })
-	return ln.Addr().String()
 }


### PR DESCRIPTION
Adds context-aware download cancellation and cancellable lock acquisition.

Fixes #778